### PR TITLE
Organize integration test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
           name: datadog-native-iast-rewriter-${{ steps.package.outputs.version }}
       - run: npm i --verbose datadog-native-iast-rewriter-${{ steps.package.outputs.version }}.tgz
       - run: npm run test:junit
-      - run: npm run test:integration
+      - run: npm run test:integration:ci
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always()

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,4 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm t
+npm run test:integration
 cargo test

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "version": "napi version",
     "test": "cross-env DD_LOCAL_VAR_NAME_HASH=test mocha --file 'test/setup.js' test/**/*.spec.js",
     "test:junit": "cross-env DD_LOCAL_VAR_NAME_HASH=test mocha --file 'test/setup.js' --reporter mocha-junit-reporter --reporter-options mochaFile=./build/junit.xml test/**/*.spec.js",
-    "test:integration": "cross-env DD_LOCAL_VAR_NAME_HASH=test mocha --file 'integration-test/setup.js' --reporter mocha-junit-reporter --reporter-options mochaFile=./build/junit-integration.xml integration-test/**/*.spec.js",
+    "test:integration": "cross-env DD_LOCAL_VAR_NAME_HASH=test mocha --file 'integration-test/setup.js' integration-test/**/*.spec.js",
+    "test:integration:ci": "cross-env DD_LOCAL_VAR_NAME_HASH=test mocha --file 'integration-test/setup.js' --reporter mocha-junit-reporter --reporter-options mochaFile=./build/junit-integration.xml integration-test/**/*.spec.js",
     "prepare": "husky install",
     "clippy": "cargo clippy --workspace -- -D warnings"
   },


### PR DESCRIPTION
### What does this PR do?

Keeps the current integration test script to be run in CI and adds a new one to be run in local which outputs the results in the stdout.
Add a new step in pre push hook to run integration test.

### Motivation

No results were displayed when running integration test.
