### PR TITLE
Filter sourcemap searching

### DIFF
--- a/test/stack_trace.spec.js
+++ b/test/stack_trace.spec.js
@@ -7,12 +7,10 @@
 
 const fs = require('fs')
 const path = require('path')
-const os = require('os')
 const proxyquire = require('proxyquire')
 
 const { getPrepareStackTrace } = require('../js/stack-trace')
 const { getSourcePathAndLineFromSourceMaps } = require('../js/source-map')
-const { expect } = require('chai')
 
 class CallSiteMock {
   constructor (fileName, lineNumber, columnNumber) {
@@ -196,7 +194,7 @@ describe('V8 filtered prepareStackTrace', () => {
     const original = Error.prepareStackTrace
     Error.prepareStackTrace = getPrepareStackTrace(original, isValidFilename)
 
-    const stackLines = new Error().stack.split(os.EOL).length - 1
+    const stackLines = new Error().stack.split('\n').length - 1
 
     Error.prepareStackTrace = original
 

--- a/test/stack_trace.spec.js
+++ b/test/stack_trace.spec.js
@@ -62,6 +62,16 @@ describe('V8 prepareStackTrace', () => {
 const sourceMapResourcesPath = path.join(__dirname, 'resources', 'stacktrace-sourcemap')
 
 describe('getFilenameFromSourceMap', () => {
+  const nodeSourceMap = require('../js/source-map/node_source_map')
+
+  const readFileSync = function (filename) {
+    if (filename.indexOf('.map') > 0) {
+      return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
+    } else if (filename.indexOf('.js') > 0) {
+      return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
+    }
+  }
+
   it('should return original object if file does not exist', () => {
     const originalPathAndLine = {
       path: path.join(sourceMapResourcesPath, 'does-not-exist.js'),
@@ -73,131 +83,60 @@ describe('getFilenameFromSourceMap', () => {
   })
 
   it('should translate with map file', () => {
+    const fileName = 'test-file.js'
     const originalPathAndLine = {
-      path: path.join(sourceMapResourcesPath, 'test-file.js'),
+      path: path.join(sourceMapResourcesPath, fileName),
       line: 5
     }
+
+    const { getSourcePathAndLineFromSourceMaps, cacheRewrittenSourceMap } = proxyquire('../js/source-map', {
+      './node_source_map': nodeSourceMap,
+      fs: { readFileSync }
+    })
+
+    const fileContent = fs.readFileSync(path.join(sourceMapResourcesPath, fileName)).toString()
+    cacheRewrittenSourceMap(originalPathAndLine.path, fileContent)
+
     const pathAndLine = getSourcePathAndLineFromSourceMaps(originalPathAndLine.path, originalPathAndLine.line, 12)
     expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-file.ts'))
     expect(pathAndLine.line).to.be.equals(2)
   })
 
   it('should translate with inlined map', () => {
+    const fileName = 'test-inline.js'
     const originalPathAndLine = {
-      path: path.join(sourceMapResourcesPath, 'test-inline.js'),
+      path: path.join(sourceMapResourcesPath, fileName),
       line: 5
     }
+    const { getSourcePathAndLineFromSourceMaps, cacheRewrittenSourceMap } = proxyquire('../js/source-map', {
+      './node_source_map': nodeSourceMap,
+      fs: { readFileSync }
+    })
+
+    const fileContent = fs.readFileSync(path.join(sourceMapResourcesPath, fileName)).toString()
+    cacheRewrittenSourceMap(originalPathAndLine.path, fileContent)
+
     const pathAndLine = getSourcePathAndLineFromSourceMaps(originalPathAndLine.path, originalPathAndLine.line, 10)
     expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-inline.ts'))
     expect(pathAndLine.line).to.be.equals(2)
   })
 
   it('should translate minified file with correct column', () => {
+    const fileName = 'test-min.min.js'
     const originalPathAndLine = {
-      path: path.join(sourceMapResourcesPath, 'test-min.min.js'),
+      path: path.join(sourceMapResourcesPath, fileName),
       line: 1
     }
-    const pathAndLine = getSourcePathAndLineFromSourceMaps(originalPathAndLine.path, originalPathAndLine.line, 23)
-    expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-min.js'))
-    expect(pathAndLine.line).to.be.equals(2)
-  })
-})
-
-describe('getFilenameFromSourceMap cache', () => {
-  const nodeSourceMap = require('../js/source-map/node_source_map')
-  afterEach(() => {
-    sinon.restore()
-  })
-
-  it('should not create two SourceMap file for the same file', () => {
-    const sourceMapSpy = sinon.spy(nodeSourceMap, 'SourceMap')
-    const { getSourcePathAndLineFromSourceMaps } = proxyquire('../js/source-map', {
-      './node_source_map': nodeSourceMap
-    })
-
-    const originalPathAndLine = {
-      path: path.join(sourceMapResourcesPath, 'test-file.js'),
-      line: 5
-    }
-    getSourcePathAndLineFromSourceMaps(originalPathAndLine.path, originalPathAndLine.line, 0)
-    getSourcePathAndLineFromSourceMaps(originalPathAndLine.path, originalPathAndLine.line, 0)
-    // eslint-disable-next-line no-unused-expressions
-    expect(sourceMapSpy).to.have.been.calledOnce
-  })
-
-  it('should has a maximum cached items', () => {
-    const sourceMapSpy = sinon.spy(nodeSourceMap, 'SourceMap')
-    const readFileSync = function (filename) {
-      if (filename.indexOf('.map') > 0) {
-        return fs.readFileSync(path.join(sourceMapResourcesPath, 'test-file.js.map'))
-      } else if (filename.indexOf('.js') > 0) {
-        return fs.readFileSync(path.join(sourceMapResourcesPath, 'test-file.js'))
-      }
-    }
-
-    const { getSourcePathAndLineFromSourceMaps } = proxyquire('../js/source-map', {
+    const { getSourcePathAndLineFromSourceMaps, cacheRewrittenSourceMap } = proxyquire('../js/source-map', {
       './node_source_map': nodeSourceMap,
       fs: { readFileSync }
     })
 
-    for (let i = 0; i < 101; i++) {
-      getSourcePathAndLineFromSourceMaps(`/source/file-${i}.js`, 5) // new entry
-      getSourcePathAndLineFromSourceMaps(`/source/file-${i}.js`, 5) // from cache
-    }
-    expect(sourceMapSpy).to.have.been.callCount(101)
-    getSourcePathAndLineFromSourceMaps('/source/file-0.js', 5)
-    expect(sourceMapSpy).to.have.been.callCount(102)
-  })
-})
+    const fileContent = fs.readFileSync(path.join(sourceMapResourcesPath, fileName)).toString()
+    cacheRewrittenSourceMap(originalPathAndLine.path, fileContent)
 
-describe('V8 filtered prepareStackTrace', () => {
-  it('should not call getSourcePathAndLineFromSourceMaps if filter function is provided', () => {
-    function isValidFilename (filename) {
-      return filename && filename.endsWith('stack_trace.spec.js')
-    }
-
-    const getSourcePathAndLineFromSourceMapsSpy = sinon.spy((path, line, column) => {
-      return { path, line, column }
-    })
-    const { getPrepareStackTrace } = proxyquire('../js/stack-trace', {
-      '../source-map': {
-        getSourcePathAndLineFromSourceMaps: getSourcePathAndLineFromSourceMapsSpy
-      }
-    })
-
-    const original = Error.prepareStackTrace
-    Error.prepareStackTrace = getPrepareStackTrace(original, isValidFilename)
-
-    // eslint-disable-next-line no-unused-expressions
-    new Error().stack
-
-    Error.prepareStackTrace = original
-
-    // eslint-disable-next-line no-unused-expressions
-    expect(getSourcePathAndLineFromSourceMapsSpy).to.have.been.calledOnce
-  })
-
-  it('should call getSourcePathAndLineFromSourceMaps if filter function is provided', () => {
-    function isValidFilename (filename) {
-      return true
-    }
-
-    const getSourcePathAndLineFromSourceMapsSpy = sinon.spy((path, line, column) => {
-      return { path, line, column }
-    })
-    const { getPrepareStackTrace } = proxyquire('../js/stack-trace', {
-      '../source-map': {
-        getSourcePathAndLineFromSourceMaps: getSourcePathAndLineFromSourceMapsSpy
-      }
-    })
-
-    const original = Error.prepareStackTrace
-    Error.prepareStackTrace = getPrepareStackTrace(original, isValidFilename)
-
-    const stackLines = new Error().stack.split('\n').length - 1
-
-    Error.prepareStackTrace = original
-
-    expect(getSourcePathAndLineFromSourceMapsSpy).to.have.been.called.callCount(stackLines)
+    const pathAndLine = getSourcePathAndLineFromSourceMaps(originalPathAndLine.path, originalPathAndLine.line, 23)
+    expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-min.js'))
+    expect(pathAndLine.line).to.be.equals(2)
   })
 })


### PR DESCRIPTION
### What does this PR do?

Adds new argument to `getPrepareStackTrace` function to filter out sourceMap files searching

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
