### PR TITLE
Fix sourceMap comment replacement

### DIFF
--- a/src/lib_napi.rs
+++ b/src/lib_napi.rs
@@ -93,7 +93,7 @@ impl Rewriter {
     pub fn rewrite(&self, code: String, file: String) -> napi::Result<ResultWithoutMetrics> {
         rewrite_js(code, &file, &self.config)
             .map(|result| ResultWithoutMetrics {
-                content: print_js(&result, self.config.chain_source_map),
+                content: print_js(&result, &self.config),
             })
             .map_err(|e| Error::new(Status::Unknown, format!("{}", e)))
     }

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -110,7 +110,7 @@ impl Rewriter {
     pub fn rewrite(&mut self, code: String, file: String) -> anyhow::Result<JsValue, JsError> {
         rewrite_js(code, &file, &self.config)
             .map(|result| Result {
-                content: print_js(&result, self.config.chain_source_map),
+                content: print_js(&result, &self.config),
                 metrics: get_metrics(result.transform_status, file),
             })
             .as_ref()

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -38,7 +38,7 @@ const SOURCE_MAP_URL: &str = "# sourceMappingURL=";
 pub struct RewrittenOutput {
     pub code: String,
     pub source_map: String,
-    pub original_map: OriginalSourceMap,
+    pub original_source_map: OriginalSourceMap,
     pub transform_status: Option<TransformStatus>,
 }
 
@@ -75,7 +75,7 @@ pub fn rewrite_js(code: String, file: &str, config: &Config) -> Result<Rewritten
         result.map(|transformed| RewrittenOutput {
             code: transformed.output.code,
             source_map: transformed.output.map.unwrap_or_default(),
-            original_map,
+            original_source_map: original_map,
             transform_status: Some(transformed.status),
         })
     })
@@ -83,13 +83,13 @@ pub fn rewrite_js(code: String, file: &str, config: &Config) -> Result<Rewritten
 
 pub fn print_js(output: &RewrittenOutput, chain_source_map: bool) -> String {
     let mut final_source_map: String = String::from(&output.source_map);
-    let original_map = &output.original_map;
+    let original_source_map = &output.original_source_map;
     if chain_source_map {
-        final_source_map = chain_source_maps(&output.source_map, &original_map.source)
+        final_source_map = chain_source_maps(&output.source_map, &original_source_map.source)
             .unwrap_or_else(|_| String::from(&output.source_map));
     }
 
-    let final_code = match &original_map.source_map_comment {
+    let final_code = match &original_source_map.source_map_comment {
         Some(comment) => output.code.replace(comment.as_str(), ""),
         _ => output.code.clone(),
     };
@@ -316,7 +316,7 @@ pub fn debug_js(code: String) -> Result<RewrittenOutput> {
         print_result.map(|printed| RewrittenOutput {
             code: printed.code,
             source_map: printed.map.unwrap(),
-            original_map,
+            original_source_map: original_map,
             transform_status: None,
         })
     });

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -81,17 +81,21 @@ pub fn rewrite_js(code: String, file: &str, config: &Config) -> Result<Rewritten
     })
 }
 
-pub fn print_js(output: &RewrittenOutput, chain_source_map: bool) -> String {
+pub fn print_js(output: &RewrittenOutput, config: &Config) -> String {
     let mut final_source_map: String = String::from(&output.source_map);
     let original_source_map = &output.original_source_map;
-    if chain_source_map {
+    if config.chain_source_map {
         final_source_map = chain_source_maps(&output.source_map, &original_source_map.source)
             .unwrap_or_else(|_| String::from(&output.source_map));
     }
 
-    let final_code = match &original_source_map.source_map_comment {
-        Some(comment) => output.code.replace(comment.as_str(), ""),
-        _ => output.code.clone(),
+    let final_code = if config.print_comments {
+        match &original_source_map.source_map_comment {
+            Some(comment) => output.code.replace(comment.as_str(), ""),
+            _ => output.code.clone(),
+        }
+    } else {
+        output.code.clone()
     };
 
     if final_source_map.is_empty() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -88,6 +88,16 @@ fn get_default_config_with_verbosity(
     }
 }
 
+fn get_chained_and_print_comments_config() -> Config {
+    Config {
+        chain_source_map: true,
+        print_comments: true,
+        local_var_prefix: "test".to_string(),
+        csi_methods: get_default_csi_methods(),
+        verbosity: TelemetryVerbosity::Debug,
+    }
+}
+
 fn csi_from_str(src: &str, dst: Option<&str>) -> CsiMethod {
     let dst_string = match dst {
         Some(str) => Some(String::from(str)),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -66,6 +66,7 @@ fn get_default_csi_methods() -> CsiMethods {
         csi_from_str("trimEnd", Some("stringTrim")),
         csi_from_str("concat", Some("stringConcat")),
         csi_from_str("slice", None),
+        csi_from_str("replace", None),
     ];
     CsiMethods::new(&mut methods)
 }

--- a/src/tests/source_map_test.rs
+++ b/src/tests/source_map_test.rs
@@ -12,7 +12,9 @@ mod tests {
 
     use crate::{
         rewriter::{print_js, rewrite_js, RewrittenOutput},
-        tests::{get_default_config, get_test_resources_folder},
+        tests::{
+            get_chained_and_print_comments_config, get_default_config, get_test_resources_folder,
+        },
     };
 
     #[derive(Clone)]
@@ -113,7 +115,7 @@ mod tests {
     #[test]
     fn test_source_maps_unchained_embedded() -> Result<(), String> {
         let rewritten = get_rewritten_js("StrUtil_embedded.js")?;
-        let result = print_js(&rewritten, false);
+        let result = print_js(&rewritten, &get_default_config(false));
         assert_that(&result).contains(SOURCE_MAP_URL);
         check_sourcemap_tokens(result, UNCHAINED_TOKENS.to_vec());
         Ok(())
@@ -122,7 +124,7 @@ mod tests {
     #[test]
     fn test_source_maps_unchained_external() -> Result<(), String> {
         let rewritten = get_rewritten_js("StrUtil_external.js")?;
-        let result = print_js(&rewritten, false);
+        let result = print_js(&rewritten, &get_default_config(false));
         assert_that(&result).contains(SOURCE_MAP_URL);
         check_sourcemap_tokens(result, UNCHAINED_TOKENS.to_vec());
         Ok(())
@@ -131,7 +133,7 @@ mod tests {
     #[test]
     fn test_source_maps_unchained_without_original_source_map() -> Result<(), String> {
         let rewritten = get_rewritten_js("StrUtil_without_sm.js")?;
-        let result = print_js(&rewritten, false);
+        let result = print_js(&rewritten, &get_default_config(false));
         assert_that(&result).contains(SOURCE_MAP_URL);
         check_sourcemap_tokens(result, UNCHAINED_TOKENS.to_vec());
         Ok(())
@@ -140,7 +142,7 @@ mod tests {
     #[test]
     fn test_source_maps_chained_embedded() -> Result<(), String> {
         let rewritten = get_rewritten_js("StrUtil_embedded.js")?;
-        let result = print_js(&rewritten, true);
+        let result = print_js(&rewritten, &get_chained_and_print_comments_config());
         assert_that(&result).contains(SOURCE_MAP_URL);
         check_sourcemap_tokens(result, CHAINED_TOKENS.to_vec());
         Ok(())
@@ -149,7 +151,7 @@ mod tests {
     #[test]
     fn test_source_maps_chained_external() -> Result<(), String> {
         let rewritten = get_rewritten_js("StrUtil_external.js")?;
-        let result = print_js(&rewritten, true);
+        let result = print_js(&rewritten, &get_chained_and_print_comments_config());
         assert_that(&result).contains(SOURCE_MAP_URL);
         check_sourcemap_tokens(result, CHAINED_TOKENS.to_vec());
         Ok(())
@@ -158,7 +160,7 @@ mod tests {
     #[test]
     fn test_source_maps_chained_without_original_source_map() -> Result<(), String> {
         let rewritten = get_rewritten_js("StrUtil_without_sm.js")?;
-        let result = print_js(&rewritten, true);
+        let result = print_js(&rewritten, &get_chained_and_print_comments_config());
         assert_that(&result).contains(SOURCE_MAP_URL);
         check_sourcemap_tokens(result, UNCHAINED_TOKENS.to_vec());
         Ok(())

--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -8,7 +8,10 @@ mod tests {
 
     use crate::{
         rewriter::print_js,
-        tests::{csi_from_str, rewrite_js, rewrite_js_with_csi_methods},
+        tests::{
+            csi_from_str, get_chained_and_print_comments_config, get_default_config, rewrite_js,
+            rewrite_js_with_csi_methods,
+        },
         visitor::csi_methods::CsiMethods,
     };
     use spectral::{assert_that, string::StrAssertions};
@@ -189,7 +192,7 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file)
             .map_err(|e| e.to_string())
-            .map(|rewrite_output| print_js(&rewrite_output, false))?;
+            .map(|rewrite_output| print_js(&rewrite_output, &get_default_config(false)))?;
 
         assert_that(&rewritten).contains("const a = {\n        __html: (__datadog_test_2 = (__datadog_test_0 = b, \
     __datadog_test_1 = __datadog_test_0.replace, _ddiast.replace(__datadog_test_1.call(__datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, ''), \
@@ -208,7 +211,9 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file)
             .map_err(|e| e.to_string())
-            .map(|rewrite_output| print_js(&rewrite_output, true))?;
+            .map(|rewrite_output| {
+                print_js(&rewrite_output, &get_chained_and_print_comments_config())
+            })?;
 
         assert_that(&rewritten).contains("const a = {\n        __html: (__datadog_test_2 = (__datadog_test_0 = b, \
     __datadog_test_1 = __datadog_test_0.replace, _ddiast.replace(__datadog_test_1.call(__datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, ''), \
@@ -225,7 +230,7 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file)
             .map_err(|e| e.to_string())
-            .map(|rewrite_output| print_js(&rewrite_output, false))?;
+            .map(|rewrite_output| print_js(&rewrite_output, &get_default_config(false)))?;
 
         assert_that(&rewritten).contains("const a = {\n        __html: (__datadog_test_2 = (__datadog_test_0 = b, \
     __datadog_test_1 = __datadog_test_0.replace, _ddiast.replace(__datadog_test_1.call(__datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, ''), \

--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -7,6 +7,7 @@
 mod tests {
 
     use crate::{
+        rewriter::print_js,
         tests::{csi_from_str, rewrite_js, rewrite_js_with_csi_methods},
         visitor::csi_methods::CsiMethods,
     };
@@ -177,6 +178,59 @@ mod tests {
                 .map_err(|e| e.to_string())?;
         assert_that(&rewritten.code).contains("let __datadog_test_0, __datadog_test_1;
     const a = (__datadog_test_0 = b, __datadog_test_1 = __datadog_test_0.plusOperator, _ddiast.plusOperator(__datadog_test_1.call(__datadog_test_0, c + d), __datadog_test_1, __datadog_test_0));");
+        Ok(())
+    }
+
+    #[test]
+    fn test_replace_with_sourcemapping() -> Result<(), String> {
+        let original_code =
+            "{const a = { __html: b.replace(/\\/\\*# sourceMappingURL=.*\\*\\//g, '') + 'other' }}"
+                .to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file)
+            .map_err(|e| e.to_string())
+            .map(|rewrite_output| print_js(&rewrite_output, false))?;
+
+        assert_that(&rewritten).contains("const a = {\n        __html: (__datadog_test_2 = (__datadog_test_0 = b, \
+    __datadog_test_1 = __datadog_test_0.replace, _ddiast.replace(__datadog_test_1.call(__datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, ''), \
+    __datadog_test_1, __datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, '')), _ddiast.plusOperator(__datadog_test_2 + 'other', __datadog_test_2, 'other'))
+    }");
+        Ok(())
+    }
+
+    #[test]
+    fn test_replace_with_sourcemapping_url() -> Result<(), String> {
+        let original_code =
+            "{const a = { __html: b.replace(/\\/\\*# sourceMappingURL=.*\\*\\//g, '') + 'other' }}
+//# sourceMappingURL=StrUtil.js.map
+        "
+            .to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file)
+            .map_err(|e| e.to_string())
+            .map(|rewrite_output| print_js(&rewrite_output, true))?;
+
+        assert_that(&rewritten).contains("const a = {\n        __html: (__datadog_test_2 = (__datadog_test_0 = b, \
+    __datadog_test_1 = __datadog_test_0.replace, _ddiast.replace(__datadog_test_1.call(__datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, ''), \
+    __datadog_test_1, __datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, '')), _ddiast.plusOperator(__datadog_test_2 + 'other', __datadog_test_2, 'other'))
+    }");
+        Ok(())
+    }
+
+    #[test]
+    fn test_replace_with_sourcemapping_url_embebbed() -> Result<(), String> {
+        let original_code = "{const a = { __html: b.replace(/\\/\\*# sourceMappingURL=.*\\*\\//g, '') + 'other' }}
+        //# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiU3RyVXRpbC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIlN0clV0aWwudHMiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6Ijs7QUFBQTtJQUFBO0lBZ0JBLENBQUM7SUFmQyxxQkFBRyxHQUFILFVBQUksQ0FBUztRQUNYLE9BQU8sR0FBRyxHQUFHLENBQUMsQ0FBQTtJQUNoQixDQUFDO0lBRU0sd0JBQU0sR0FBYixVQUFjLENBQVMsRUFBRSxDQUFTO1FBQ2hDLE9BQU8sQ0FBQyxHQUFHLElBQUksQ0FBQyxHQUFHLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFBO0lBQ3BDLENBQUM7SUFFTSx1QkFBSyxHQUFaLFVBQWEsQ0FBUztRQUNwQixPQUFPLENBQUMsQ0FBQyxRQUFRLEVBQUUsQ0FBQTtJQUNyQixDQUFDO0lBRU0scUJBQUcsR0FBVixVQUFXLENBQVMsRUFBRSxDQUFTO1FBQzdCLE9BQU8sQ0FBQyxHQUFHLENBQUMsQ0FBQTtJQUNkLENBQUM7SUFDSCxjQUFDO0FBQUQsQ0FBQyxBQWhCRCxJQWdCQyJ9
+        ".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file)
+            .map_err(|e| e.to_string())
+            .map(|rewrite_output| print_js(&rewrite_output, false))?;
+
+        assert_that(&rewritten).contains("const a = {\n        __html: (__datadog_test_2 = (__datadog_test_0 = b, \
+    __datadog_test_1 = __datadog_test_0.replace, _ddiast.replace(__datadog_test_1.call(__datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, ''), \
+    __datadog_test_1, __datadog_test_0, /\\/\\*# sourceMappingURL=.*\\*\\//g, '')), _ddiast.plusOperator(__datadog_test_2 + 'other', __datadog_test_2, 'other'))
+    }");
         Ok(())
     }
 }


### PR DESCRIPTION

### What does this PR do?

Save original sourceMap comment for later processing and replace sourceMap expression only if found before.

### Motivation

Avoid errors in javascript files with expressions containing `//# sourceMap` text

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
