### PR TITLE
Find path and line using original sourcemap

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1,25 +1,22 @@
 Component,Origin,License,Copyright
-require,instant,BSD-3-Clause,Copyright (c) 2019 Sébastien Crozet
-require,napi,MIT,Copyright (c) 2020-present LongYinan
-require,napi-derive,MIT,Copyright (c) 2020-present LongYinan
-require,swc,Apache-2.0,Copyright 강동윤
-require,swc_ecma_visit,Apache-2.0,Copyright 강동윤
-require,swc_ecma_parser,Apache-2.0,Copyright 강동윤
-require,swc_visit_macros,Apache-2.0,Copyright 강동윤
-require,base64,MIT and Apache-2.0,Copyright (c) 2015 Alice Maz
 require,anyhow,MIT OR Apache-2.0,Copyright (c) 2018 David Tolnay
-require,fastrand,Apache-2.0 OR MIT, Copyright 2020 Stjepan Glavina
-require,node-gyp-build,MIT,Copyright 2017 Mathias Buus
-require,wasm-bindgen,Apache-2.0 OR MIT,Copyright (c) 2014 Alex Crichton
-require,serde,MIT OR Apache-2.0,Copyright (c) Erick Tryzelaar and David Tolnay
-require,serde-wasm-bindgen,MIT,Copyright (c) 2019 Cloudflare Inc.
+require,base64,MIT and Apache-2.0,Copyright (c) 2015 Alice Maz
 require,console_error_panic_hook,MIT OR Apache-2.0,Copyright (c) 2018 Nick Fitzgerald
+require,fastrand,Apache-2.0 OR MIT, Copyright 2020 Stjepan Glavina
+require,instant,BSD-3-Clause,Copyright (c) 2019 Sébastien Crozet
 require,js-sys,MIT OR Apache-2.0,Copyright (c) 2014 Alex Crichton
 require,log,Apache-2.0 OR MIT,Copyright (c) 2014 The Rust Project Developers
-dev,napi-build,MIT,Copyright (c) 2020-present LongYinan
-dev,tempfile,MIT OR Apache-2.0,Copyright (c) 2015 Steven Allen
-dev,spectral,Apache-2.0,Copyright (c) cfrancia
-dev,ctor,Apache-2.0 OR MIT,Copyright (c) 2018 Matt Mastracci
+require,lru-cache,ISC,Copyright (c) 2010-2022 Isaac Z. Schlueter and Contributors
+require,napi,MIT,Copyright (c) 2020-present LongYinan
+require,napi-derive,MIT,Copyright (c) 2020-present LongYinan
+require,node-gyp-build,MIT,Copyright 2017 Mathias Buus
+require,serde,MIT OR Apache-2.0,Copyright (c) Erick Tryzelaar and David Tolnay
+require,serde-wasm-bindgen,MIT,Copyright (c) 2019 Cloudflare Inc.
+require,swc,Apache-2.0,Copyright 강동윤
+require,swc_ecma_parser,Apache-2.0,Copyright 강동윤
+require,swc_ecma_visit,Apache-2.0,Copyright 강동윤
+require,swc_visit_macros,Apache-2.0,Copyright 강동윤
+require,wasm-bindgen,Apache-2.0 OR MIT,Copyright (c) 2014 Alex Crichton
 dev,@babel/core,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
 dev,@babel/parser,MIT,Copyright (c) Copyright (C) 2012-2014 by various contributors
 dev,@babel/types,MIT,Copyright (c) 2014-present Sebastian McKenzie and other contributors
@@ -28,6 +25,7 @@ dev,@swc-node/register,MIT,Copyright (c) 2020-present LongYinan
 dev,ast-types,MIT,Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>
 dev,chai,MIT,Copyright (c) 2017 Chai.js Assertion Library
 dev,cross-env,MIT,Copyright (c) 2017 Kent C. Dodds
+dev,ctor,Apache-2.0 OR MIT,Copyright (c) 2018 Matt Mastracci
 dev,dotenv-cli,MIT,Copyright Jens Claes
 dev,eslint-config-standard,MIT,Copyright (c) Feross Aboukhadijeh
 dev,eslint-plugin-import,MIT,Copyright (c) 2015 Ben Mosher
@@ -40,12 +38,15 @@ dev,lint-staged,MIT,Copyright (c) 2016 Andrey Okonetchnikov
 dev,mocha,MIT,Copyright (c) 2011-2021 OpenJS Foundation and contributors
 dev,mocha-it-each,MIT,Copyright (c) 2013 Mikejsdev
 dev,mocha-junit-reporter,MIT,Copyright (c) 2015 Michael Allen
+dev,napi-build,MIT,Copyright (c) 2020-present LongYinan
 dev,npm-run-all,MIT,Copyright (c) 2015 Toru Nagashima
 dev,recast,MIT,Copyright (c) 2012 Ben Newman <bn@cs.stanford.edu
 dev,prettier,MIT,Copyright © James Long and contributors
 dev,sorcery,MIT,Copyright 2014 Rich-Harris
 dev,source-map,BSD-3-Clause,Copyright (c) 2009-2011 Mozilla Foundation and contributors
+dev,spectral,Apache-2.0,Copyright (c) cfrancia
 dev,tap-junit,MIT,Copyright (c) 2018 Dustin Hershman
+dev,tempfile,MIT OR Apache-2.0,Copyright (c) 2015 Steven Allen
 dev,tmp,MIT,Copyright (c) 2014 KARASZI István
 dev,typescript,Apache License 2.0,Copyright (c) Microsoft Corporation
 dev,sinon,BSD-3-Clause,Copyright 2010-2017 Christian Johansen

--- a/js/source-map/index.js
+++ b/js/source-map/index.js
@@ -67,7 +67,8 @@ function getOriginalPathAndLine (filename, line, column = 0) {
     try {
       let sourceMap = originalSourceMapsCache.get(filename)
       if (sourceMap === undefined) {
-        sourceMap = generateSourceMapFromFileContent(fs.readFileSync(filename).toString(), filename)
+        const filePath = getFilePathFromName(filename)
+        sourceMap = generateSourceMapFromFileContent(fs.readFileSync(filename).toString(), filePath)
         originalSourceMapsCache.set(filename, sourceMap || null)
       }
       return getPathAndLine(sourceMap, filename, line, column)

--- a/js/source-map/index.js
+++ b/js/source-map/index.js
@@ -67,7 +67,7 @@ function getOriginalPathAndLine (filename, line, column = 0) {
     try {
       let sourceMap = originalSourceMapsCache.get(filename)
       if (sourceMap === undefined) {
-        sourceMap = generateSourceMapFromFileContent(fs.readFileSync(filename), filename)
+        sourceMap = generateSourceMapFromFileContent(fs.readFileSync(filename).toString(), filename)
         originalSourceMapsCache.set(filename, sourceMap || null)
       }
       return getPathAndLine(sourceMap, filename, line, column)

--- a/js/source-map/index.js
+++ b/js/source-map/index.js
@@ -62,7 +62,7 @@ function getSourcePathAndLineFromSourceMaps (filename, line, column = 0) {
   return getPathAndLine(sourceMap, filename, line, column)
 }
 
-function getOriginalPathAndLine (filename, line, column = 0) {
+function getOriginalPathAndLineFromSourceMap (filename, line, column = 0) {
   if (filename && line) {
     try {
       let sourceMap = originalSourceMapsCache.get(filename)
@@ -81,7 +81,7 @@ function getOriginalPathAndLine (filename, line, column = 0) {
 
 module.exports = {
   getSourcePathAndLineFromSourceMaps,
-  getOriginalPathAndLine,
+  getOriginalPathAndLineFromSourceMap,
   cacheRewrittenSourceMap,
   generateSourceMapFromFileContent
 }

--- a/js/source-map/index.js
+++ b/js/source-map/index.js
@@ -20,7 +20,7 @@ function generateSourceMapFromFileContent (fileContent, filePath) {
   } else if (lastLine.indexOf(SOURCE_MAP_LINE_START) === 0) {
     let sourceMappingURL = lastLine.substring(SOURCE_MAP_LINE_START.length)
     if (sourceMappingURL) {
-      sourceMappingURL = path.join(filePath, sourceMappingURL)
+      sourceMappingURL = path.isAbsolute(sourceMappingURL) ? sourceMappingURL : path.join(filePath, sourceMappingURL)
       rawSourceMap = fs.readFileSync(sourceMappingURL).toString()
     }
   }

--- a/js/source-map/index.js
+++ b/js/source-map/index.js
@@ -64,8 +64,9 @@ function getSourcePathAndLineFromSourceMaps (filename, line, column = 0) {
 
 function getOriginalPathAndLineFromSourceMap (filename, line, column = 0) {
   if (filename && line) {
+    let sourceMap
     try {
-      let sourceMap = originalSourceMapsCache.get(filename)
+      sourceMap = originalSourceMapsCache.get(filename)
       if (sourceMap === undefined) {
         const filePath = getFilePathFromName(filename)
         sourceMap = generateSourceMapFromFileContent(fs.readFileSync(filename).toString(), filePath)
@@ -73,7 +74,9 @@ function getOriginalPathAndLineFromSourceMap (filename, line, column = 0) {
       }
       return getPathAndLine(sourceMap, filename, line, column)
     } catch (e) {
-      // do nothing
+      if (sourceMap === undefined) {
+        originalSourceMapsCache.set(filename, null)
+      }
     }
   }
   return { path: filename, line, column }

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@
  **/
 'use strict'
 const { getPrepareStackTrace } = require('./js/stack-trace/')
-const { cacheRewrittenSourceMap, getOriginalPathAndLine } = require('./js/source-map')
+const { cacheRewrittenSourceMap, getOriginalPathAndLineFromSourceMap } = require('./js/source-map')
 
 class DummyRewriter {
   rewrite (code, file) {
@@ -70,5 +70,5 @@ module.exports = {
   Rewriter: getRewriter(),
   DummyRewriter,
   getPrepareStackTrace,
-  getOriginalPathAndLine
+  getOriginalPathAndLineFromSourceMap
 }

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@
  **/
 'use strict'
 const { getPrepareStackTrace } = require('./js/stack-trace/')
-const { cacheRewrittenSourceMap } = require('./js/source-map')
+const { cacheRewrittenSourceMap, getOriginalPathAndLine } = require('./js/source-map')
 
 class DummyRewriter {
   rewrite (code, file) {
@@ -69,5 +69,6 @@ function getRewriter () {
 module.exports = {
   Rewriter: getRewriter(),
   DummyRewriter,
-  getPrepareStackTrace
+  getPrepareStackTrace,
+  getOriginalPathAndLine
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.0-pre",
       "license": "Apache-2.0",
       "dependencies": {
+        "lru-cache": "^7.14.0",
         "node-gyp-build": "^4.5.0"
       },
       "devDependencies": {
@@ -3922,15 +3923,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/md5": {
@@ -5306,6 +5303,18 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -9067,13 +9076,9 @@
       }
     },
     "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
     },
     "md5": {
       "version": "2.3.0",
@@ -10105,6 +10110,17 @@
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
       }
     },
     "serialize-javascript": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/DataDog/dd-native-iast-rewriter-js/issues"
   },
   "dependencies": {
+    "lru-cache": "^7.14.0",
     "node-gyp-build": "^4.5.0"
   },
   "devDependencies": {

--- a/test/resources/stacktrace-sourcemap/test-min.min.js
+++ b/test/resources/stacktrace-sourcemap/test-min.min.js
@@ -1,4 +1,5 @@
-export function test() {
+function test() {
   return 'test something'
 }
+export { test }
 //# sourceMappingURL=test-min.min.js.map

--- a/test/resources/stacktrace-sourcemap/test-min.min.js
+++ b/test/resources/stacktrace-sourcemap/test-min.min.js
@@ -1,5 +1,4 @@
-function test() {
+export function test() {
   return 'test something'
 }
-export { test }
 //# sourceMappingURL=test-min.min.js.map

--- a/test/stack_trace.spec.js
+++ b/test/stack_trace.spec.js
@@ -214,4 +214,18 @@ describe('getOriginalPathAndLine', () => {
     expect(pathAndLine.path).to.be.equals('error')
     expect(pathAndLine.line).to.be.equals(42)
   })
+
+  it('should resolve sourceMappgingURL file correctly', () => {
+    const fileName = 'test-min.min.js'
+    const originalPathAndLine = {
+      path: path.join(sourceMapResourcesPath, fileName),
+      line: 1
+    }
+
+    const pathAndLine = getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 23)
+
+    expect(setLRU).to.be.calledOnceWith(originalPathAndLine.path)
+    expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-min.js'))
+    expect(pathAndLine.line).to.be.equals(2)
+  })
 })

--- a/test/stack_trace.spec.js
+++ b/test/stack_trace.spec.js
@@ -63,9 +63,7 @@ const sourceMapResourcesPath = path.join(__dirname, 'resources', 'stacktrace-sou
 const nodeSourceMap = require('../js/source-map/node_source_map')
 const { expect } = require('chai')
 const readFileSync = function (filename) {
-  if (filename.indexOf('.map') > 0) {
-    return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
-  } else if (filename.indexOf('.js') > 0) {
+  if (filename.indexOf('.map') > 0 || filename.indexOf('.js') > 0) {
     return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
   }
 }
@@ -167,7 +165,7 @@ describe('getOriginalPathAndLine', () => {
           case 'error':
             throw new Error('errr')
           default:
-            return readFileSync(filename).toString()
+            return readFileSync(filename)
         }
       }
     }

--- a/test/stack_trace.spec.js
+++ b/test/stack_trace.spec.js
@@ -138,7 +138,7 @@ describe('getFilenameFromSourceMap', () => {
   })
 })
 
-describe('getOriginalPathAndLine', () => {
+describe('getOriginalPathAndLineFromSourceMapFromSourceMap', () => {
   const sourceMapsMap = new Map()
   const setLRU = sinon.spy()
   const getLRU = sinon.spy()
@@ -154,7 +154,7 @@ describe('getOriginalPathAndLine', () => {
     }
   }
 
-  const { getOriginalPathAndLine } = proxyquire('../js/source-map', {
+  const { getOriginalPathAndLineFromSourceMap } = proxyquire('../js/source-map', {
     'lru-cache': LRU,
     './node_source_map': nodeSourceMap,
     fs: {
@@ -183,7 +183,7 @@ describe('getOriginalPathAndLine', () => {
   })
 
   it('should add SourceMap to cache', () => {
-    const pathAndLine = getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
+    const pathAndLine = getOriginalPathAndLineFromSourceMap(originalPathAndLine.path, originalPathAndLine.line, 12)
 
     expect(setLRU).to.be.calledOnceWith(originalPathAndLine.path)
     expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-inline.ts'))
@@ -191,10 +191,10 @@ describe('getOriginalPathAndLine', () => {
   })
 
   it('should reuse previously cached SourceMap', () => {
-    const pathAndLine = getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
+    const pathAndLine = getOriginalPathAndLineFromSourceMap(originalPathAndLine.path, originalPathAndLine.line, 12)
 
-    getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
-    getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
+    getOriginalPathAndLineFromSourceMap(originalPathAndLine.path, originalPathAndLine.line, 12)
+    getOriginalPathAndLineFromSourceMap(originalPathAndLine.path, originalPathAndLine.line, 12)
 
     expect(setLRU).to.be.calledOnceWith(originalPathAndLine.path)
     expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-inline.ts'))
@@ -202,27 +202,27 @@ describe('getOriginalPathAndLine', () => {
   })
 
   it('should not try to load again a previously failed SourceMap', () => {
-    getOriginalPathAndLine('no-sourcemap', originalPathAndLine.line, 12)
-    getOriginalPathAndLine('no-sourcemap', originalPathAndLine.line, 12)
-    getOriginalPathAndLine('no-sourcemap', originalPathAndLine.line, 12)
+    getOriginalPathAndLineFromSourceMap('no-sourcemap', originalPathAndLine.line, 12)
+    getOriginalPathAndLineFromSourceMap('no-sourcemap', originalPathAndLine.line, 12)
+    getOriginalPathAndLineFromSourceMap('no-sourcemap', originalPathAndLine.line, 12)
 
     expect(setLRU).to.be.calledOnceWith('no-sourcemap', null)
   })
 
   it('should return the original path and line if there is an Error', () => {
-    const pathAndLine = getOriginalPathAndLine('error', 42, 12)
+    const pathAndLine = getOriginalPathAndLineFromSourceMap('error', 42, 12)
     expect(pathAndLine.path).to.be.equals('error')
     expect(pathAndLine.line).to.be.equals(42)
   })
 
-  it('should resolve sourceMappgingURL file correctly', () => {
+  it('should resolve sourceMappingURL file correctly', () => {
     const fileName = 'test-min.min.js'
     const originalPathAndLine = {
       path: path.join(sourceMapResourcesPath, fileName),
       line: 1
     }
 
-    const pathAndLine = getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 23)
+    const pathAndLine = getOriginalPathAndLineFromSourceMap(originalPathAndLine.path, originalPathAndLine.line, 23)
 
     expect(setLRU).to.be.calledOnceWith(originalPathAndLine.path)
     expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-min.js'))

--- a/test/stack_trace.spec.js
+++ b/test/stack_trace.spec.js
@@ -60,18 +60,17 @@ describe('V8 prepareStackTrace', () => {
 })
 
 const sourceMapResourcesPath = path.join(__dirname, 'resources', 'stacktrace-sourcemap')
+const nodeSourceMap = require('../js/source-map/node_source_map')
+const { expect } = require('chai')
+const readFileSync = function (filename) {
+  if (filename.indexOf('.map') > 0) {
+    return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
+  } else if (filename.indexOf('.js') > 0) {
+    return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
+  }
+}
 
 describe('getFilenameFromSourceMap', () => {
-  const nodeSourceMap = require('../js/source-map/node_source_map')
-
-  const readFileSync = function (filename) {
-    if (filename.indexOf('.map') > 0) {
-      return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
-    } else if (filename.indexOf('.js') > 0) {
-      return fs.readFileSync(path.join(sourceMapResourcesPath, path.basename(filename)))
-    }
-  }
-
   it('should return original object if file does not exist', () => {
     const originalPathAndLine = {
       path: path.join(sourceMapResourcesPath, 'does-not-exist.js'),
@@ -138,5 +137,83 @@ describe('getFilenameFromSourceMap', () => {
     const pathAndLine = getSourcePathAndLineFromSourceMaps(originalPathAndLine.path, originalPathAndLine.line, 23)
     expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-min.js'))
     expect(pathAndLine.line).to.be.equals(2)
+  })
+})
+
+describe('getOriginalPathAndLine', () => {
+  const sourceMapsMap = new Map()
+  const setLRU = sinon.spy()
+  const getLRU = sinon.spy()
+  class LRU {
+    set (key, value) {
+      setLRU(key, value)
+      return sourceMapsMap.set(key, value)
+    }
+
+    get (key) {
+      getLRU(key)
+      return sourceMapsMap.get(key)
+    }
+  }
+
+  const { getOriginalPathAndLine } = proxyquire('../js/source-map', {
+    'lru-cache': LRU,
+    './node_source_map': nodeSourceMap,
+    fs: {
+      readFileSync: (filename) => {
+        switch (filename) {
+          case 'no-sourcemap':
+            return ''
+          case 'error':
+            throw new Error('errr')
+          default:
+            return readFileSync(filename).toString()
+        }
+      }
+    }
+  })
+
+  const fileName = 'test-inline.js'
+  const originalPathAndLine = {
+    path: path.join(sourceMapResourcesPath, fileName),
+    line: 5
+  }
+
+  afterEach(() => {
+    sinon.reset()
+    sourceMapsMap.clear()
+  })
+
+  it('should add SourceMap to cache', () => {
+    const pathAndLine = getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
+
+    expect(setLRU).to.be.calledOnceWith(originalPathAndLine.path)
+    expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-inline.ts'))
+    expect(pathAndLine.line).to.be.equals(2)
+  })
+
+  it('should reuse previously cached SourceMap', () => {
+    const pathAndLine = getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
+
+    getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
+    getOriginalPathAndLine(originalPathAndLine.path, originalPathAndLine.line, 12)
+
+    expect(setLRU).to.be.calledOnceWith(originalPathAndLine.path)
+    expect(pathAndLine.path).to.be.equals(path.join(sourceMapResourcesPath, 'test-inline.ts'))
+    expect(pathAndLine.line).to.be.equals(2)
+  })
+
+  it('should not try to load again a previously failed SourceMap', () => {
+    getOriginalPathAndLine('no-sourcemap', originalPathAndLine.line, 12)
+    getOriginalPathAndLine('no-sourcemap', originalPathAndLine.line, 12)
+    getOriginalPathAndLine('no-sourcemap', originalPathAndLine.line, 12)
+
+    expect(setLRU).to.be.calledOnceWith('no-sourcemap', null)
+  })
+
+  it('should return the original path and line if there is an Error', () => {
+    const pathAndLine = getOriginalPathAndLine('error', 42, 12)
+    expect(pathAndLine.path).to.be.equals('error')
+    expect(pathAndLine.line).to.be.equals(42)
   })
 })


### PR DESCRIPTION
### What does this PR do?

Exports a new method called `getOriginalPathAndLine` in charge of read from disk a javascript file, check if it contains a sourceMapping, parse or load it and search the corresponding token to the line and column passed as arguments.
If line and column are found it will return an object with the path, line and column in the original source file.

### Motivation
When IAST detects a vulnerability, it contains the location (file and line) where the vulnerability has been found. If the file points to a source file, like in the case of a transpiled typescript or minimized js files, we can resolve the vulnerability location to the original source file.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [x] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
