### PR TITLE
Remove init method and initialize logger only if configured

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,6 @@ export interface RewriterConfig {
 export interface ResultWithoutMetrics {
   content: string
 }
-export function init(): void
 export class Rewriter {
   constructor(config?: RewriterConfig | undefined | null)
   rewrite(code: string, file: string): ResultWithoutMetrics

--- a/index.js
+++ b/index.js
@@ -218,7 +218,6 @@ if (!nativeBinding) {
   throw new Error('Failed to load native binding')
 }
 
-const { Rewriter, init } = nativeBinding
+const { Rewriter } = nativeBinding
 
 module.exports.Rewriter = Rewriter
-module.exports.init = init

--- a/main.js
+++ b/main.js
@@ -57,7 +57,6 @@ class CacheRewriter {
 function getRewriter () {
   try {
     const iastRewriter = require('./wasm/wasm_iast_rewriter')
-    iastRewriter.init()
 
     NativeRewriter = iastRewriter.Rewriter
     return CacheRewriter

--- a/src/lib_napi.rs
+++ b/src/lib_napi.rs
@@ -111,8 +111,3 @@ impl Rewriter {
             .collect())
     }
 }
-
-#[napi]
-pub fn init() -> napi::Result<()> {
-    Ok(())
-}

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -100,13 +100,6 @@ impl RewriterConfig {
     }
 }
 
-// Wasm module init function. Should it be called automatically if anotated with #[wasm_bindgen(start)]?
-// at the moment it is invoked when the wasm module is loaded in main.js
-#[wasm_bindgen]
-pub fn init() {
-    tracer_logger::init();
-}
-
 #[wasm_bindgen]
 pub struct Rewriter {
     config: Config,

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -11,7 +11,6 @@ use crate::{
 use anyhow::{Error, Result};
 use log::debug;
 use std::{
-    borrow::Borrow,
     collections::HashMap,
     io::Read,
     path::{Path, PathBuf},
@@ -72,13 +71,13 @@ pub fn rewrite_js<R: Read>(
 
     let compiler = Compiler::new(Arc::new(common::SourceMap::new(FilePathMapping::empty())));
     try_with_handler(compiler.cm.clone(), default_handler_opts(), |handler| {
-        let program = parse_js(&code, file, handler, compiler.borrow())?;
+        let program = parse_js(&code, file, handler, &compiler)?;
 
         // extract sourcemap before printing otherwise comments are consumed
         // and looks like it is not possible to read them after compiler.print() invocation
         let original_map = extract_source_map(file, compiler.comments(), file_reader);
 
-        let result = transform_js(program, &code, file, config, compiler.borrow());
+        let result = transform_js(program, &code, file, config, &compiler);
 
         result.map(|transformed| RewrittenOutput {
             code: transformed.output.code,
@@ -324,7 +323,7 @@ pub fn debug_js(code: String) -> Result<RewrittenOutput> {
     let compiler = Compiler::new(Arc::new(common::SourceMap::new(FilePathMapping::empty())));
     return try_with_handler(compiler.cm.clone(), default_handler_opts(), |handler| {
         let js_file = "debug.js".to_string();
-        let program = parse_js(&code, &js_file, handler, compiler.borrow())?;
+        let program = parse_js(&code, &js_file, handler, &compiler)?;
 
         print!("{:#?}", program);
 

--- a/src/tracer_logger.rs
+++ b/src/tracer_logger.rs
@@ -58,12 +58,12 @@ impl Log for TracerLogger<'_> {
     fn flush(&self) {}
 }
 
-static LOGGER_INITIATED: AtomicBool = AtomicBool::new(false);
+static LOGGER_INITIALIZED: AtomicBool = AtomicBool::new(false);
 
 pub fn set_logger(logger: &JsValue, level: &str) -> anyhow::Result<JsValue, JsValue> {
-    if !LOGGER_INITIATED.load(Ordering::Relaxed) {
+    if !LOGGER_INITIALIZED.load(Ordering::Relaxed) {
         log::set_boxed_logger(Box::new(TracerLogger::default()))
-            .map(|_| LOGGER_INITIATED.store(true, Ordering::Relaxed))
+            .map(|_| LOGGER_INITIALIZED.store(true, Ordering::Relaxed))
             .map_err(|err| JsValue::from_str(&format!("{err:?}")))
             .and_then(|_| set_logger_and_level(logger, level))
     } else {


### PR DESCRIPTION
### What does this PR do?
Changes the way logger is initialized

### Motivation

Seems that logger initialization is a bit of a heavy operation so this PR removes the automatic initialization and only initializes the logger when it is enabled by configuration.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
