### PR TITLE
Check if new RegExp has arguments

### DIFF
--- a/src/visitor/literal_visitor.rs
+++ b/src/visitor/literal_visitor.rs
@@ -166,7 +166,11 @@ impl Visit for LiteralVisitor {
                         && new_exp
                             .args
                             .as_ref()
-                            .map(|args| args[0].spread.is_none() && args[0].expr.is_lit())
+                            .map(|args| {
+                                !args.is_empty()
+                                    && args[0].spread.is_none()
+                                    && args[0].expr.is_lit()
+                            })
                             .is_some()
                     {
                         // if the call is a new RegExp('regex') skip visiting children

--- a/test/literals.spec.js
+++ b/test/literals.spec.js
@@ -120,4 +120,11 @@ describe('hardcoded literals', () => {
     expect(result.literalsResult).to.not.undefined
     expect(result.literalsResult.literals).to.deep.eq([])
   })
+
+  it('does not fail with an empty regexp constructor', () => {
+    const js = 'const reg = new RegExp();'
+    const result = rewriteWithOpts(js)
+
+    expect(result.literalsResult).to.not.undefined
+  })
 })


### PR DESCRIPTION
### What does this PR do?
Fixes a problem with calls to new RegExp with no arguments :S

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
