### PR TITLE
Avoid reading sourceMaps for unmodified source files and catch errors if any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,9 +15,16 @@ export interface RewriterConfig {
   csiMethods?: Array<CsiMethod>
   literals?: boolean
 }
-export interface ResultWithoutMetrics {
+export interface Result {
   content: string
+  metrics?: Metrics
   literalsResult?: LiteralsResult
+}
+export interface Metrics {
+  status: string
+  instrumentedPropagation: number
+  file: string
+  propagationDebug?: Record<string, number>
 }
 export interface LiteralsResult {
   file: string
@@ -34,6 +41,6 @@ export interface LiteralInfo {
 }
 export class Rewriter {
   constructor(config?: RewriterConfig | undefined | null)
-  rewrite(code: string, file: string): ResultWithoutMetrics
+  rewrite(code: string, file: string): Result
   csiMethods(): Array<string>
 }

--- a/js/source-map/index.js
+++ b/js/source-map/index.js
@@ -14,9 +14,13 @@ function generateSourceMapFromFileContent (fileContent, filePath) {
   const fileLines = fileContent.trim().split('\n')
   const lastLine = fileLines[fileLines.length - 1]
   let rawSourceMap
+
+  // all rewritten source files have the sourceMap inlined
   if (lastLine.indexOf(SOURCE_MAP_INLINE_LINE_START) === 0) {
     const sourceMapInBase64 = lastLine.substring(SOURCE_MAP_INLINE_LINE_START.length)
     rawSourceMap = Buffer.from(sourceMapInBase64, 'base64').toString('utf8')
+
+    // unmodified source files could originally point to a sourceMap file but it could not exist
   } else if (lastLine.indexOf(SOURCE_MAP_LINE_START) === 0) {
     let sourceMappingURL = lastLine.substring(SOURCE_MAP_LINE_START.length)
     if (sourceMappingURL) {
@@ -30,8 +34,10 @@ function generateSourceMapFromFileContent (fileContent, filePath) {
 }
 
 function cacheRewrittenSourceMap (filename, fileContent) {
-  const sm = generateSourceMapFromFileContent(fileContent, getFilePathFromName(filename))
-  rewrittenSourceMapsCache.set(filename, sm)
+  if (fileContent) {
+    const sm = generateSourceMapFromFileContent(fileContent, getFilePathFromName(filename))
+    rewrittenSourceMapsCache.set(filename, sm)
+  }
 }
 
 function getFilePathFromName (filename) {

--- a/main.js
+++ b/main.js
@@ -33,11 +33,11 @@ class CacheRewriter {
     const response = this.nativeRewriter.rewrite(code, file)
 
     try {
-      cacheRewrittenSourceMap(file, response.content)
+      const { metrics, content } = response
+      if (metrics?.status === 'modified') {
+        cacheRewrittenSourceMap(file, content)
+      }
     } catch (e) {
-      // all rewritten source files have the sourceMap inlined so this error can occur when trying
-      // to read a sourcemap of an unmodified source file from disk: because the file doesn't exist
-      // o because we don't have permissions to read it
       this.logError(e)
     }
 

--- a/main.js
+++ b/main.js
@@ -61,9 +61,7 @@ class CacheRewriter {
   }
 
   logError (e) {
-    if (this.logger?.error) {
-      this.logger.error(e)
-    }
+    this.logger?.error?.(e)
   }
 }
 

--- a/scripts/crawler.js
+++ b/scripts/crawler.js
@@ -226,7 +226,7 @@ crawl(options.rootPath, options, {
         const metrics = response.metrics
         if (metrics) {
           cyan(`status: ${metrics.status}`)
-          if (metrics.status !== 'NotModified') {
+          if (metrics.status?.toLowerCase() !== 'notmodified') {
             cyan(`count: ${metrics.instrumentedPropagation}`)
             if (metrics.propagationDebug && metrics.propagationDebug.size > 0) {
               cyan(metrics.propagationDebug)

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -229,7 +229,7 @@ impl Rewriter {
 fn get_metrics(status: Option<TransformStatus>, file: &str) -> Option<Metrics> {
     if let Some(transform_status) = status {
         return Some(Metrics {
-            status: transform_status.status.to_string(),
+            status: transform_status.status.to_string().to_lowercase(),
             instrumented_propagation: transform_status.telemetry.get_instrumented_propagation(),
             propagation_debug: transform_status.telemetry.get_propagation_debug(),
             file: file.to_owned(),

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -23,6 +23,7 @@ describe('main', () => {
     cacheRewrittenSourceMap = sinon.stub()
     main = proxyquire('../main', {
       './wasm/wasm_iast_rewriter': {
+        '@noCallThru': true,
         Rewriter
       },
       './js/source-map': {
@@ -30,9 +31,7 @@ describe('main', () => {
       }
     })
 
-    rewriter = new main.Rewriter({
-      logLevel: 'ERROR'
-    })
+    rewriter = new main.Rewriter()
   })
 
   it('loads sourceMap when source file has been modified', () => {

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -1,0 +1,61 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+ **/
+/* eslint-disable no-unused-expressions */
+
+const proxyquire = require('proxyquire')
+
+describe('main', () => {
+  let main, rewriter, status, cacheRewrittenSourceMap
+  beforeEach(() => {
+    class Rewriter {
+      rewrite (code, file) {
+        return {
+          content: 'content',
+          metrics: {
+            status
+          }
+        }
+      }
+    }
+
+    cacheRewrittenSourceMap = sinon.stub()
+    main = proxyquire('../main', {
+      './wasm/wasm_iast_rewriter': {
+        Rewriter
+      },
+      './js/source-map': {
+        cacheRewrittenSourceMap
+      }
+    })
+
+    rewriter = new main.Rewriter()
+  })
+
+  it('loads sourceMap when source file has been modified', () => {
+    status = 'modified'
+
+    const response = rewriter.rewrite('content', 'file')
+
+    expect(response.metrics.status).to.eq('modified')
+    expect(cacheRewrittenSourceMap).to.be.calledOnceWith('file', 'content')
+  })
+
+  it('does not load sourceMap when source file has not been modified', () => {
+    status = 'notmodified'
+
+    const response = rewriter.rewrite('content', 'file')
+
+    expect(response.metrics.status).to.eq('notmodified')
+    expect(cacheRewrittenSourceMap).to.not.be.called
+  })
+
+  it('should catch errors produced in cacheRewrittenSourceMap', () => {
+    status = 'modified'
+
+    cacheRewrittenSourceMap.throws(() => new Error('Error reading sourceMap file'))
+
+    expect(() => rewriter.rewrite('content', 'file')).to.not.throw
+  })
+})

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -30,7 +30,9 @@ describe('main', () => {
       }
     })
 
-    rewriter = new main.Rewriter()
+    rewriter = new main.Rewriter({
+      logLevel: 'ERROR'
+    })
   })
 
   it('loads sourceMap when source file has been modified', () => {
@@ -56,6 +58,6 @@ describe('main', () => {
 
     cacheRewrittenSourceMap.throws(() => new Error('Error reading sourceMap file'))
 
-    expect(() => rewriter.rewrite('content', 'file')).to.not.throw
+    expect(() => rewriter.rewrite('content', 'file')).to.not.throw()
   })
 })

--- a/test/rewriter_config.spec.js
+++ b/test/rewriter_config.spec.js
@@ -149,7 +149,7 @@ _ddiast.plus("b" + c, "b", c));
 
       const metrics = response.metrics
       expect(metrics).to.not.be.undefined
-      expect(metrics.status).eq('Modified')
+      expect(metrics.status).eq('modified')
       expect(metrics.instrumentedPropagation).eq(0)
       expect(metrics.propagationDebug).to.be.undefined
     })
@@ -162,7 +162,7 @@ _ddiast.plus("b" + c, "b", c));
 
       const metrics = response.metrics
       expect(metrics).to.not.be.undefined
-      expect(metrics.status).eq('Modified')
+      expect(metrics.status).eq('modified')
       expect(metrics.instrumentedPropagation).eq(1)
       expect(metrics.propagationDebug).to.be.undefined
     })
@@ -175,7 +175,7 @@ _ddiast.plus("b" + c, "b", c));
 
       const metrics = response.metrics
       expect(metrics).to.not.be.undefined
-      expect(metrics.status).eq('Modified')
+      expect(metrics.status).eq('modified')
       expect(metrics.instrumentedPropagation).eq(1)
       expect(metrics.propagationDebug).to.be.undefined
     })
@@ -188,7 +188,7 @@ _ddiast.plus("b" + c, "b", c));
 
       const metrics = response.metrics
       expect(metrics).to.not.be.undefined
-      expect(metrics.status).eq('Modified')
+      expect(metrics.status).eq('modified')
       expect(metrics.instrumentedPropagation).eq(1)
       expect(metrics.propagationDebug.size).eq(1)
       expect(metrics.propagationDebug.get('+')).eq(1)
@@ -202,7 +202,7 @@ _ddiast.plus("b" + c, "b", c));
 
       const metrics = response.metrics
       expect(metrics).to.not.be.undefined
-      expect(metrics.status).eq('Modified')
+      expect(metrics.status).eq('modified')
       expect(metrics.instrumentedPropagation).eq(1)
     })
 
@@ -214,7 +214,7 @@ _ddiast.plus("b" + c, "b", c));
 
       const metrics = response.metrics
       expect(metrics).to.not.be.undefined
-      expect(metrics.status).eq('Modified')
+      expect(metrics.status).eq('modified')
       expect(metrics.instrumentedPropagation).eq(1)
       expect(metrics.propagationDebug).to.be.undefined
     })


### PR DESCRIPTION
### What does this PR do?
- Avoid reading sourceMaps if source file has not been modified
- Catch errors produced when reading sourceMap files

### Motivation

All rewritten source files have the sourceMap inlined so when the source file is not modified and it originally contained a sourceMappingUrl pointing to a sourceMap file we try to read it. If the sourceMap file doesn't exist or we don't have permissions to read it an Error is thrown reaching the tracer and producing a telemetry log.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
