### PR TITLE
Export kSymbolPrepareStackTrace

### DIFF
--- a/js/stack-trace/index.js
+++ b/js/stack-trace/index.js
@@ -87,9 +87,15 @@ function getPrepareStackTrace (originalPrepareStackTrace) {
 
   const wrappedPrepareStackTrace = (error, structuredStackTrace) => {
     if (originalPrepareStackTrace) {
-      const parsedCallSites = structuredStackTrace.map((callSite) => new WrappedCallSite(callSite))
+      let parsedCallSites
+      try {
+        parsedCallSites = structuredStackTrace.map((callSite) => new WrappedCallSite(callSite))
+      } catch (e) {
+        parsedCallSites = structuredStackTrace
+      }
       return originalPrepareStackTrace(error, parsedCallSites)
     }
+
     const stackLines = error.stack.split('\n')
     let firstIndex = -1
     for (let i = 0; i < stackLines.length; i++) {
@@ -138,5 +144,6 @@ function getPrepareStackTrace (originalPrepareStackTrace) {
 }
 
 module.exports = {
-  getPrepareStackTrace
+  getPrepareStackTrace,
+  kSymbolPrepareStackTrace
 }

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
  **/
 'use strict'
-const { getPrepareStackTrace } = require('./js/stack-trace/')
+const { getPrepareStackTrace, kSymbolPrepareStackTrace } = require('./js/stack-trace/')
 const { cacheRewrittenSourceMap, getOriginalPathAndLineFromSourceMap } = require('./js/source-map')
 
 class DummyRewriter {
@@ -80,5 +80,6 @@ module.exports = {
   Rewriter: getRewriter(),
   DummyRewriter,
   getPrepareStackTrace,
-  getOriginalPathAndLineFromSourceMap
+  getOriginalPathAndLineFromSourceMap,
+  kSymbolPrepareStackTrace
 }


### PR DESCRIPTION
### What does this PR do?

Export `kSymbolPrepareStackTrace` & protect `wrappedPrepareStackTrace` path

### Motivation

Be able to check the `kSymbolPrepareStackTrace` symbol in the iast part to ensure it has wrapped the `prepareStrackTrace` function before reset it.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
