### PR TITLE
Support rewrite on methods without callee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2526,9 +2526,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2538,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2576,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ export interface CsiMethod {
   src: string
   dst?: string
   operator?: boolean
+  allowedWithoutCallee?: boolean
 }
 export interface RewriterConfig {
   chainSourceMap?: boolean

--- a/scripts/crawler.js
+++ b/scripts/crawler.js
@@ -34,7 +34,8 @@ const CSI_METHODS = [
   { src: 'toLocaleLowerCase' },
   { src: 'toLocaleUpperCase' },
   { src: 'toLowerCase' },
-  { src: 'toUpperCase' }
+  { src: 'toUpperCase' },
+  { src: 'eval', allowedWithoutCallee: true }
 ]
 
 const GLOBAL_METHODS_TEMPLATE = `;(function(globals){

--- a/src/lib_napi.rs
+++ b/src/lib_napi.rs
@@ -22,6 +22,7 @@ pub struct CsiMethod {
     pub src: String,
     pub dst: Option<String>,
     pub operator: Option<bool>,
+    pub allowed_without_callee: Option<bool>,
 }
 
 #[napi(object)]
@@ -45,6 +46,7 @@ impl RewriterConfig {
                             m.src.clone(),
                             m.dst.clone(),
                             m.operator.unwrap_or(false),
+                            m.allowed_without_callee.unwrap_or(false),
                         )
                     })
                     .collect::<Vec<visitor::csi_methods::CsiMethod>>(),

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -169,7 +169,7 @@ impl Rewriter {
 
         let rewriter_config = serde_wasm_bindgen::from_value::<RewriterConfig>(config_js);
         let config: Config = rewriter_config
-            .unwrap_or_else(|_| RewriterConfig::default())
+            .unwrap_or(RewriterConfig::default())
             .to_config();
 
         Self { config }

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -28,6 +28,7 @@ pub struct CsiMethod {
     pub src: String,
     pub dst: Option<String>,
     pub operator: Option<bool>,
+    pub allowed_without_callee: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -80,6 +81,7 @@ impl RewriterConfig {
                             m.src.clone(),
                             m.dst.clone(),
                             m.operator.unwrap_or(false),
+                            m.allowed_without_callee.unwrap_or(false),
                         )
                     })
                     .collect::<Vec<visitor::csi_methods::CsiMethod>>(),
@@ -167,7 +169,7 @@ impl Rewriter {
 
         let rewriter_config = serde_wasm_bindgen::from_value::<RewriterConfig>(config_js);
         let config: Config = rewriter_config
-            .unwrap_or(RewriterConfig::default())
+            .unwrap_or_else(|_| RewriterConfig::default())
             .to_config();
 
         Self { config }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -129,7 +129,7 @@ fn csi_from_str(src: &str, dst: Option<&str>) -> CsiMethod {
         Some(str) => Some(String::from(str)),
         None => None,
     };
-    CsiMethod::new(String::from(src), dst_string, false)
+    CsiMethod::new(String::from(src), dst_string, false, false)
 }
 
 fn csi_op_from_str(src: &str, dst: Option<&str>) -> CsiMethod {
@@ -137,5 +137,5 @@ fn csi_op_from_str(src: &str, dst: Option<&str>) -> CsiMethod {
         Some(str) => Some(String::from(str)),
         None => None,
     };
-    CsiMethod::new(String::from(src), dst_string, true)
+    CsiMethod::new(String::from(src), dst_string, true, false)
 }

--- a/src/tracer_logger.rs
+++ b/src/tracer_logger.rs
@@ -72,6 +72,6 @@ pub fn set_logger(logger: &JsValue, level: &str) -> anyhow::Result<JsValue, JsVa
 }
 
 fn set_logger_and_level(logger: &JsValue, level: &str) -> anyhow::Result<JsValue, JsValue> {
-    log::set_max_level(LevelFilter::from_str(level).unwrap_or(log::max_level()));
+    log::set_max_level(LevelFilter::from_str(level).unwrap_or_else(|_| log::max_level()));
     setLogger(logger)
 }

--- a/src/tracer_logger.rs
+++ b/src/tracer_logger.rs
@@ -22,25 +22,17 @@ extern "C" {
 
 pub struct TracerLogger<'a> {
     pub logger: LoggerFn<'a>,
-    pub level_filter: LevelFilter,
 }
 
 impl<'a> TracerLogger<'a> {
-    pub fn new(level: &str, logger: LoggerFn<'a>) -> Self {
-        TracerLogger {
-            logger,
-            level_filter: LevelFilter::from_str(level).unwrap_or(LevelFilter::Off),
-        }
-    }
-
-    pub fn with_level(level: &str) -> Self {
-        Self::new(level, &|level, msg| {
-            log(&level.into(), &msg.into()).ok();
-        })
+    pub fn new(logger: LoggerFn<'a>) -> Self {
+        TracerLogger { logger }
     }
 
     pub fn default() -> Self {
-        Self::with_level("ERROR")
+        Self::new(&|level, msg| {
+            log(&level.into(), &msg.into()).ok();
+        })
     }
 }
 

--- a/src/tracer_logger.rs
+++ b/src/tracer_logger.rs
@@ -64,6 +64,6 @@ pub fn set_logger(logger: &JsValue, level: &str) -> anyhow::Result<JsValue, JsVa
 }
 
 fn set_logger_and_level(logger: &JsValue, level: &str) -> anyhow::Result<JsValue, JsValue> {
-    log::set_max_level(LevelFilter::from_str(level).unwrap_or_else(|_| log::max_level()));
+    log::set_max_level(LevelFilter::from_str(level).unwrap_or(log::max_level()));
     setLogger(logger)
 }

--- a/src/transform/call_expr_transform.rs
+++ b/src/transform/call_expr_transform.rs
@@ -40,7 +40,7 @@ impl CallExprTransform {
                     (Expr::Lit(literal), MemberProp::Ident(ident)) => {
                         if csi_methods.method_allows_literal_callers(&ident.sym) {
                             replace_call_expr_if_csi_method(
-                                Some(&Expr::Lit(literal)),
+                                &Expr::Lit(literal),
                                 ident,
                                 call,
                                 csi_methods,
@@ -53,7 +53,7 @@ impl CallExprTransform {
 
                     (Expr::Ident(obj), MemberProp::Ident(ident)) => {
                         replace_call_expr_if_csi_method(
-                            Some(&Expr::Ident(obj)),
+                            &Expr::Ident(obj),
                             ident,
                             call,
                             csi_methods,
@@ -63,7 +63,7 @@ impl CallExprTransform {
 
                     (Expr::Call(callee_call), MemberProp::Ident(ident)) => {
                         replace_call_expr_if_csi_method(
-                            Some(&Expr::Call(callee_call)),
+                            &Expr::Call(callee_call),
                             ident,
                             call,
                             csi_methods,
@@ -73,7 +73,7 @@ impl CallExprTransform {
 
                     (Expr::Paren(paren), MemberProp::Ident(ident)) => {
                         replace_call_expr_if_csi_method(
-                            Some(&Expr::Paren(paren)),
+                            &Expr::Paren(paren),
                             ident,
                             call,
                             csi_methods,
@@ -83,7 +83,7 @@ impl CallExprTransform {
 
                     (Expr::Array(paren), MemberProp::Ident(ident)) => {
                         replace_call_expr_if_csi_method(
-                            Some(&Expr::Array(paren)),
+                            &Expr::Array(paren),
                             ident,
                             call,
                             csi_methods,
@@ -106,7 +106,7 @@ impl CallExprTransform {
                         } else if !FunctionPrototypeTransform::member_prop_is_prototype(&member_obj)
                         {
                             replace_call_expr_if_csi_method(
-                                Some(&Expr::Member(member_obj)),
+                                &Expr::Member(member_obj),
                                 ident,
                                 call,
                                 csi_methods,
@@ -119,9 +119,12 @@ impl CallExprTransform {
                     _ => None,
                 },
 
-                Expr::Ident(obj) => {
-                    replace_call_expr_if_csi_method(None, &obj, call, csi_methods, ident_provider)
-                }
+                Expr::Ident(obj) => replace_call_expr_if_csi_method_without_callee(
+                    &obj,
+                    call,
+                    csi_methods,
+                    ident_provider,
+                ),
                 _ => None,
             },
             _ => None,
@@ -159,24 +162,20 @@ fn replace_prototype_call_or_apply(
 }
 
 fn replace_call_expr_if_csi_method(
-    expr_op: Option<&Expr>,
+    expr: &Expr,
     ident: &Ident,
     call: &mut CallExpr,
     csi_methods: &CsiMethods,
     ident_provider: &mut dyn IdentProvider,
 ) -> Option<ResultExpr> {
-    if let Some(expr) = expr_op {
-        replace_call_expr_if_csi_method_with_member(
-            expr,
-            ident,
-            call,
-            csi_methods,
-            None,
-            ident_provider,
-        )
-    } else {
-        replace_call_expr_if_csi_method_without_callee(ident, call, csi_methods, ident_provider)
-    }
+    replace_call_expr_if_csi_method_with_member(
+        expr,
+        ident,
+        call,
+        csi_methods,
+        None,
+        ident_provider,
+    )
 }
 
 fn replace_call_expr_if_csi_method_without_callee(

--- a/src/transform/call_expr_transform.rs
+++ b/src/transform/call_expr_transform.rs
@@ -194,11 +194,11 @@ fn replace_call_expr_if_csi_method_without_callee(
 
             // let __datadog_test_0;
             // (__datadog_test_0 = arg0, _ddiast.aloneMethod
-            // (aloneMethod(__datadog_test_0), aloneMethod, global, __datadog_test_0));
+            // (aloneMethod(__datadog_test_0), aloneMethod, undefined, __datadog_test_0));
             arguments.push(Expr::Ident(ident.clone()));
             let global = Ident {
                 span,
-                sym: JsWord::from("global"),
+                sym: JsWord::from("undefined"),
                 optional: false,
             };
             arguments.push(Expr::Ident(global));

--- a/src/transform/call_expr_transform.rs
+++ b/src/transform/call_expr_transform.rs
@@ -194,6 +194,9 @@ fn replace_call_expr_if_csi_method_with_member(
             let mut call_replacement = call.clone();
 
             if let Some(expr_orig) = expr_opt {
+                // replace original call expression with a parent expression splitting every component and finally invoking .call
+                //  a) a.substring() -> __datadog_token_$i = a, __datadog_token_$i2 = __datadog_token_$i.substring, __datadog_token_$i2.call(__datadog_token_$i, __datadog_token_$i2)
+                //  b) String.prototype.substring.[call|apply](a) -> __datadog_token_$i = a, __datadog_token_$i2 = String.prototype.substring, __datadog_token_$i2.call(__datadog_token_$i, __datadog_token_$i2)
                 let expr = expr_orig.clone();
                 let ident_replacement = ident_provider.get_temporal_ident_used_in_assignation(
                     &expr,
@@ -283,11 +286,9 @@ fn replace_call_expr_if_csi_method_with_member(
                     ),
                 });
             } else {
-                /*
-                        let __datadog_test_0;
-                (__datadog_test_0 = arg0, _ddiast.aloneMethod
-                (aloneMethod(__datadog_test_0), aloneMethod, global, __datadog_test_0));
-                         */
+                // let __datadog_test_0;
+                // (__datadog_test_0 = arg0, _ddiast.aloneMethod
+                // (aloneMethod(__datadog_test_0), aloneMethod, global, __datadog_test_0));
                 arguments.push(Expr::Ident(ident.clone()));
                 let global = Ident {
                     span,

--- a/src/visitor/csi_methods.rs
+++ b/src/visitor/csi_methods.rs
@@ -9,12 +9,23 @@ pub struct CsiMethod {
     pub src: String,
     pub dst: String,
     pub operator: bool,
+    pub allowed_without_callee: bool,
 }
 
 impl CsiMethod {
-    pub fn new(src: String, dst: Option<String>, operator: bool) -> Self {
+    pub fn new(
+        src: String,
+        dst: Option<String>,
+        operator: bool,
+        allowed_without_callee: bool,
+    ) -> Self {
         let dst = dst.unwrap_or_else(|| src.clone());
-        CsiMethod { src, dst, operator }
+        CsiMethod {
+            src,
+            dst,
+            operator,
+            allowed_without_callee,
+        }
     }
 }
 

--- a/src/visitor/visitor_util.rs
+++ b/src/visitor/visitor_util.rs
@@ -37,7 +37,6 @@ pub fn get_dd_call_expr(expr: &Expr, arguments: &[Expr], method_name: &str, span
         expr: Box::new(expr.clone()),
         spread: None,
     }];
-    print!("{:?}", arguments);
     args.append(
         &mut arguments
             .iter()

--- a/src/visitor/visitor_util.rs
+++ b/src/visitor/visitor_util.rs
@@ -37,7 +37,7 @@ pub fn get_dd_call_expr(expr: &Expr, arguments: &[Expr], method_name: &str, span
         expr: Box::new(expr.clone()),
         spread: None,
     }];
-
+    print!("{:?}", arguments);
     args.append(
         &mut arguments
             .iter()

--- a/src/visitor/visitor_util.rs
+++ b/src/visitor/visitor_util.rs
@@ -37,6 +37,7 @@ pub fn get_dd_call_expr(expr: &Expr, arguments: &[Expr], method_name: &str, span
         expr: Box::new(expr.clone()),
         spread: None,
     }];
+
     args.append(
         &mut arguments
             .iter()

--- a/test/method_without_callee.spec.js
+++ b/test/method_without_callee.spec.js
@@ -8,9 +8,30 @@ describe('Method without callee', () => {
     rewriteAndExpect(
       js,
       `{
-let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-(__datadog_test_0 = undefined, __datadog_test_1 = aloneMethod, __datadog_test_2 = arg0, _ddiast.aloneMethod\
-(__datadog_test_1.call(__datadog_test_0, __datadog_test_2), __datadog_test_1, __datadog_test_0, __datadog_test_2));
+let __datadog_test_0;
+(__datadog_test_0 = arg0, _ddiast.aloneMethod\
+(aloneMethod(__datadog_test_0), aloneMethod, global, __datadog_test_0));
+}`
+    )
+  })
+
+  it('should rewrite aloneMethod with 2 args', () => {
+    const js = 'aloneMethod(arg0, obj.arg1)'
+    rewriteAndExpect(
+      js,
+      `{
+let __datadog_test_0, __datadog_test_1;
+(__datadog_test_0 = arg0, __datadog_test_1 = obj.arg1, _ddiast.aloneMethod\
+(aloneMethod(__datadog_test_0, __datadog_test_1), aloneMethod, global, __datadog_test_0, __datadog_test_1));
+}`
+    )
+  })
+  it('should rewrite aloneMethod without args', () => {
+    const js = 'aloneMethod()'
+    rewriteAndExpect(
+      js,
+      `{
+_ddiast.aloneMethod(aloneMethod(), aloneMethod, global);
 }`
     )
   })

--- a/test/method_without_callee.spec.js
+++ b/test/method_without_callee.spec.js
@@ -10,7 +10,7 @@ describe('Method without callee', () => {
       `{
 let __datadog_test_0;
 (__datadog_test_0 = arg0, _ddiast.aloneMethod\
-(aloneMethod(__datadog_test_0), aloneMethod, global, __datadog_test_0));
+(aloneMethod(__datadog_test_0), aloneMethod, undefined, __datadog_test_0));
 }`
     )
   })
@@ -22,7 +22,7 @@ let __datadog_test_0;
       `{
 let __datadog_test_0, __datadog_test_1;
 (__datadog_test_0 = arg0, __datadog_test_1 = obj.arg1, _ddiast.aloneMethod\
-(aloneMethod(__datadog_test_0, __datadog_test_1), aloneMethod, global, __datadog_test_0, __datadog_test_1));
+(aloneMethod(__datadog_test_0, __datadog_test_1), aloneMethod, undefined, __datadog_test_0, __datadog_test_1));
 }`
     )
   })
@@ -31,7 +31,7 @@ let __datadog_test_0, __datadog_test_1;
     rewriteAndExpect(
       js,
       `{
-_ddiast.aloneMethod(aloneMethod(), aloneMethod, global);
+_ddiast.aloneMethod(aloneMethod(), aloneMethod, undefined);
 }`
     )
   })

--- a/test/method_without_callee.spec.js
+++ b/test/method_without_callee.spec.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { rewriteAndExpect } = require('./util')
+
+describe('Method without callee', () => {
+  it('should rewrite aloneMethod', () => {
+    const js = 'aloneMethod(arg0)'
+    rewriteAndExpect(
+      js,
+      `{
+let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+(__datadog_test_0 = undefined, __datadog_test_1 = aloneMethod, __datadog_test_2 = arg0, _ddiast.aloneMethod\
+(__datadog_test_1.call(__datadog_test_0, __datadog_test_2), __datadog_test_1, __datadog_test_0, __datadog_test_2));
+}`
+    )
+  })
+
+  it('should rewrite aloneMethod when it is called with callee', () => {
+    const js = 'obj.aloneMethod(arg0)'
+    rewriteAndExpect(
+      js,
+      `{
+let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+(__datadog_test_0 = obj, __datadog_test_1 = __datadog_test_0.aloneMethod, __datadog_test_2 = arg0, _ddiast.aloneMethod\
+(__datadog_test_1.call(__datadog_test_0, __datadog_test_2), __datadog_test_1, __datadog_test_0, __datadog_test_2));
+}`
+    )
+  })
+
+  it('should not rewrite method not configured as alone when it is used alone', () => {
+    const js = 'cantAloneMethod(arg0)'
+    rewriteAndExpect(js, '{cantAloneMethod(arg0)}')
+  })
+})

--- a/test/util.js
+++ b/test/util.js
@@ -32,7 +32,9 @@ const csiMethods = [
   { src: 'replace' },
   { src: 'replaceAll' },
   { src: 'slice' },
-  { src: 'concat' }
+  { src: 'concat' },
+  { src: 'aloneMethod', allowedWithoutCallee: true },
+  { src: 'cantAloneMethod' }
 ]
 
 const rewriteWithOpts = (code, opts) => {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Support rewriting methods without callee, like `method(param)`  instead of `obj.method(param)`. 

### Motivation
Are methods that we want to instrument with rewriter that can be used without callee, like `eval`

<!-- What inspired you to submit this pull request? -->


### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Unit tests have been updated and pass
