### PR TITLE
Set GITHUB_TOKEN permissions for create_release job in release workflow

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -130,6 +130,8 @@ jobs:
         target:
           - name: alpine 64 bits
             dockerfile: test.alpine.Dockerfile
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -98,6 +98,8 @@ jobs:
             architecture: x64
 
     runs-on: ${{ matrix.target.os }}
+    permissions:
+      checks: write
     env:
       NPM_REWRITER: true
     steps:
@@ -125,13 +127,13 @@ jobs:
   test-docker:
     needs: ['wasm-pack']
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     strategy:
       matrix:
         target:
           - name: alpine 64 bits
             dockerfile: test.alpine.Dockerfile
-    permissions:
-      checks: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,10 +134,10 @@ jobs:
             artifact: darwin-x64
 
     runs-on: ${{ matrix.target.os }}
-    env:
-      NPM_REWRITER: true
     permissions:
       checks: write
+    env:
+      NPM_REWRITER: true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -162,6 +162,8 @@ jobs:
   test-docker:
     needs: ['pack']
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
     strategy:
       matrix:
         target:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,8 @@ jobs:
     runs-on: ${{ matrix.target.os }}
     env:
       NPM_REWRITER: true
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment: release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: codex-team/action-nodejs-package-info@v1.1


### PR DESCRIPTION
### What does this PR do?

Set `contents: write` permission in `create_release` job
Set `checks: write` for `mikepenz/action-junit-report` action

### Motivation

After changing the default workflow permissions in the repo, it is necessary to adjust the permissions in the workflow file.

### Additional Notes

[Create release endpoint doc](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release)

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
