### PR TITLE
Rewrite some expressions like String.prototype[concat|replace].[call|apply]("literal", ...args)

### DIFF
--- a/docker/v8test.Dockerfile
+++ b/docker/v8test.Dockerfile
@@ -14,7 +14,7 @@ COPY ./scripts/crawler.js /build/package/scripts/crawler.js
 RUN npm i --prefix package
 
 # rewrite v8 mjsunit test files
-RUN node package/scripts/crawler.js --override v8/test/mjsunit/ '^(str|arr|arg|num|rege|mod|glob|obj|val|whit|this|throw|try|unbox|pro|call|code|comp|func|for|field).*'
+RUN node package/scripts/crawler.js --override v8/test/mjsunit/ '^(str|arr|arg|num|rege|mod|glob|obj|val|whit|this|throw|try|unbox|pro|call|code|comp|func|for|field|substr|unicode).*'
 
 # launch mjsunit tests
 CMD ["/build/v8/tools/run-tests.py", "--outdir=out/x64.release", "mjsunit"]

--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -115,8 +115,8 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-    const a = (__datadog_test_0 = 1, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = a(), _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, __datadog_test_2, 3), __datadog_test_1, __datadog_test_0, __datadog_test_2, 3));");
+            .contains("let __datadog_test_0, __datadog_test_1;
+    const a = (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a(), _ddiast.stringConcat(__datadog_test_0.call(1, __datadog_test_1, 3), __datadog_test_0, 1, __datadog_test_1, 3));");
         Ok(())
     }
 

--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -110,6 +110,26 @@ mod tests {
     }
 
     #[test]
+    fn test_prototype_concat_call() -> Result<(), String> {
+        let original_code = "{const a = String.prototype.concat.call(1,a(),3)}".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
+        assert_that(&rewritten.code)
+            .contains("let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+    const a = (__datadog_test_0 = 1, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = a(), _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, __datadog_test_2, 3), __datadog_test_1, __datadog_test_0, __datadog_test_2, 3));");
+        Ok(())
+    }
+
+    #[test]
+    fn test_prototype_concat_call_literals() -> Result<(), String> {
+        let original_code = "{const a = String.prototype.concat.call(1,2,3)}".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
+        assert_that(&rewritten.code).contains("const a = String.prototype.concat.call(1,2,3)");
+        Ok(())
+    }
+
+    #[test]
     fn test_ident_trim() -> Result<(), String> {
         let original_code = "{const a = b.trim();}".to_string();
         let js_file = "test.js".to_string();

--- a/src/transform/call_expr_transform.rs
+++ b/src/transform/call_expr_transform.rs
@@ -145,7 +145,10 @@ fn replace_prototype_call_or_apply(
     ident_provider: &mut dyn IdentProvider,
 ) -> Option<ResultExpr> {
     let prototype_call_option = FunctionPrototypeTransform::get_expression_parts_from_call_or_apply(
-        call, member, ident_name,
+        call,
+        member,
+        ident_name,
+        csi_methods,
     );
 
     match prototype_call_option {

--- a/src/transform/function_prototype_transform.rs
+++ b/src/transform/function_prototype_transform.rs
@@ -143,10 +143,5 @@ fn all_args_are_literal(args: &[ExprOrSpread]) -> bool {
 }
 
 fn is_undefined_or_null(expr: &Expr) -> bool {
-    if expr.is_ident() {
-        let ident = expr.as_ident().unwrap();
-        return ident.sym == "undefined" || ident.sym == "null";
-    }
-
-    false
+    expr.is_ident_ref_to("undefined") || expr.is_ident_ref_to("null")
 }

--- a/src/transform/function_prototype_transform.rs
+++ b/src/transform/function_prototype_transform.rs
@@ -50,9 +50,6 @@ impl FunctionPrototypeTransform {
                 return None;
             }
 
-            let method_ident = path_parts[0].clone();
-            let this_expr = &call.args[0].expr;
-
             let mut filtered_args = vec![];
             if !filter_call_args(
                 &call.args,
@@ -61,6 +58,9 @@ impl FunctionPrototypeTransform {
             ) {
                 return None;
             }
+
+            let method_ident = path_parts[0].clone();
+            let this_expr = &call.args[0].expr;
 
             if this_expr.is_lit()
                 && (!csi_methods.method_allows_literal_callers(&method_ident.sym)

--- a/src/transform/function_prototype_transform.rs
+++ b/src/transform/function_prototype_transform.rs
@@ -138,5 +138,15 @@ fn get_prototype_member_path(member: &MemberExpr, parts: &mut Vec<Ident>) -> boo
 }
 
 fn all_args_are_literal(args: &[ExprOrSpread]) -> bool {
-    args.iter().all(|elem| elem.expr.is_lit())
+    args.iter()
+        .all(|elem| elem.expr.is_lit() || is_undefined_or_null(&elem.expr))
+}
+
+fn is_undefined_or_null(expr: &Expr) -> bool {
+    if expr.is_ident() {
+        let ident = expr.as_ident().unwrap();
+        return ident.sym == "undefined" || ident.sym == "null";
+    }
+
+    false
 }

--- a/src/transform/operand_handler.rs
+++ b/src/transform/operand_handler.rs
@@ -27,12 +27,14 @@ pub trait OperandHandler {
             Expr::Ident(_) => {
                 if ident_mode == IdentMode::Replace {
                     operand.map_with_mut(|op| {
-                        Expr::Ident(ident_provider.get_ident_used_in_assignation(
+                        let ident = ident_provider.get_ident_used_in_assignation(
                             &op,
                             assignations,
                             arguments,
                             span,
-                        ))
+                        );
+
+                        ident.map_or(op, Expr::Ident)
                     })
                 } else {
                     arguments.push(operand.clone())
@@ -70,12 +72,10 @@ pub trait OperandHandler {
         ident_provider: &mut dyn IdentProvider,
     ) {
         operand.map_with_mut(|op| {
-            Expr::Ident(ident_provider.get_ident_used_in_assignation(
-                &op,
-                assignations,
-                arguments,
-                span,
-            ))
+            let ident =
+                ident_provider.get_ident_used_in_assignation(&op, assignations, arguments, span);
+
+            ident.map_or(op, Expr::Ident)
         })
     }
 

--- a/test/string_method.spec.js
+++ b/test/string_method.spec.js
@@ -163,6 +163,11 @@ _ddiast.stringSubstring(__datadog_test_1.call(__datadog_test_0, 2), __datadog_te
       rewriteAndExpectNoTransformation(js)
     })
 
+    it('does not modify String.prototype.substring direct call', () => {
+      const js = 'String.prototype.substring.call("abc", 0, a);'
+      rewriteAndExpectNoTransformation(js)
+    })
+
     it('does modify member.prop.substring call', () => {
       const js = 'a.b.c.substring(1);'
       rewriteAndExpect(
@@ -203,6 +208,11 @@ _ddiast.stringSubstring(__datadog_test_1.call(__datadog_test_0, 2), __datadog_te
   describe('concat (method that allows literals)', () => {
     it('does not modify String.prototype.concat call if all args are literals', () => {
       const js = 'String.prototype.concat.call("hello", "world");'
+      rewriteAndExpectNoTransformation(js)
+    })
+
+    it('does modify String.prototype.concat call if args are literals and null', () => {
+      const js = 'String.prototype.concat.call("hello", 2, undefined, null);'
       rewriteAndExpectNoTransformation(js)
     })
 

--- a/test/string_method.spec.js
+++ b/test/string_method.spec.js
@@ -221,10 +221,10 @@ _ddiast.stringSubstring(__datadog_test_1.call(__datadog_test_0, 2), __datadog_te
       rewriteAndExpect(
         js,
         `{
-  let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-(__datadog_test_0 = "hello", __datadog_test_1 = String.prototype.concat, __datadog_test_2 = a, _ddiast.concat(\
-__datadog_test_1.call(__datadog_test_0, __datadog_test_2, "world"), __datadog_test_1, __datadog_test_0, \
-__datadog_test_2, "world"));
+  let __datadog_test_0, __datadog_test_1;
+(__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+__datadog_test_0.call("hello", __datadog_test_1, "world"), __datadog_test_0, "hello", \
+__datadog_test_1, "world"));
       }`
       )
     })
@@ -251,10 +251,10 @@ __datadog_test_0, "world", null), __datadog_test_1, __datadog_test_0, "world", n
       rewriteAndExpect(
         js,
         `{
-  let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-(__datadog_test_0 = "hello", __datadog_test_1 = String.prototype.concat, __datadog_test_2 = a, \
-_ddiast.concat(__datadog_test_1.call(__datadog_test_0, "world", __datadog_test_2), __datadog_test_1, \
-__datadog_test_0, "world", __datadog_test_2));
+  let __datadog_test_0, __datadog_test_1;
+(__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, \
+_ddiast.concat(__datadog_test_0.call("hello", "world", __datadog_test_1), __datadog_test_0, \
+"hello", "world", __datadog_test_1));
       }`
       )
     })
@@ -299,9 +299,9 @@ __datadog_test_0, "world", __datadog_test_2));
             const js = builder.build(`return 'a'.${method}(${args});`)
             rewriteAndExpectAndExpectEval(
               js,
-              builder.build(`let __datadog_test_0, __datadog_test_1;
-        return (__datadog_test_0 = 'a', __datadog_test_1 = __datadog_test_0.${method}, _ddiast.${method}(\
-__datadog_test_1.call(__datadog_test_0${argsWithComma}), __datadog_test_1, __datadog_test_0${argsWithComma}));`)
+              builder.build(`let __datadog_test_0;
+        return (__datadog_test_0 = 'a'.${method}, _ddiast.${method}(\
+__datadog_test_0.call('a'${argsWithComma}), __datadog_test_0, 'a'${argsWithComma}));`)
             )
           })
         } else {


### PR DESCRIPTION
### What does this PR do?

Rewrite some more expressions like String.prototype.concat.call() or String.prototype.concat.apply() when first argument (this) is a literal
It is able to detect if all arguments in the expression are literals to skip the rewriting.

### Motivation

This will be useful for the new template literal rewriting process

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
