### PR TITLE
spread operator support

### DIFF
--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -134,7 +134,7 @@ mod tests {
         let original_code = "{const c = String.prototype.concat.call(...a)}".to_string();
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
-        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.stringConcat(__datadog_test_0.call(...__datadog_test_1), __datadog_test_0, ...__datadog_test_1));");
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = [\n        ...a\n    ], _ddiast.stringConcat(__datadog_test_0.call(...__datadog_test_1), __datadog_test_0, ...__datadog_test_1));");
         Ok(())
     }
 
@@ -143,7 +143,7 @@ mod tests {
         let original_code = "{const c = String.prototype.concat.call(a, ...b)}".to_string();
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
-        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = b, _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = [\n        ...b\n    ], _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
         Ok(())
     }
 
@@ -152,7 +152,7 @@ mod tests {
         let original_code = "{const c = String.prototype.concat.apply(a, ...b)}".to_string();
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
-        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = b, _ddiast.stringConcat(__datadog_test_1.apply(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = [\n        ...b\n    ], _ddiast.stringConcat(__datadog_test_1.apply(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
         Ok(())
     }
 
@@ -161,7 +161,7 @@ mod tests {
         let original_code = "{const c = a.concat(...b)}".to_string();
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
-        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = [\n        ...b\n    ], _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
         Ok(())
     }
 
@@ -170,7 +170,7 @@ mod tests {
         let original_code = "{const c = String.prototype.concat.call(a, ...b, ...c)}".to_string();
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
-        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = b, __datadog_test_3 = c, _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2, ...__datadog_test_3), __datadog_test_1, __datadog_test_0, ...__datadog_test_2, ...__datadog_test_3));");
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = [\n        ...b\n    ], __datadog_test_3 = [\n        ...c\n    ], _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2, ...__datadog_test_3), __datadog_test_1, __datadog_test_0, ...__datadog_test_2, ...__datadog_test_3));");
         Ok(())
     }
 

--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -139,6 +139,24 @@ mod tests {
     }
 
     #[test]
+    fn test_concat_args_spread() -> Result<(), String> {
+        let original_code = "{const c = a.concat(...b)}".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
+        Ok(())
+    }
+
+    #[test]
+    fn test_prototype_concat_call_args_spread_multiple() -> Result<(), String> {
+        let original_code = "{const c = String.prototype.concat.call(a, ...b, ...c)}".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = b, __datadog_test_3 = c, _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2, ...__datadog_test_3), __datadog_test_1, __datadog_test_0, ...__datadog_test_2, ...__datadog_test_3));");
+        Ok(())
+    }
+
+    #[test]
     fn test_ident_trim() -> Result<(), String> {
         let original_code = "{const a = b.trim();}".to_string();
         let js_file = "test.js".to_string();

--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -130,6 +130,15 @@ mod tests {
     }
 
     #[test]
+    fn test_prototype_concat_call_args_spread() -> Result<(), String> {
+        let original_code = "{const c = String.prototype.concat.call(a, ...b)}".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = b, _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
+        Ok(())
+    }
+
+    #[test]
     fn test_ident_trim() -> Result<(), String> {
         let original_code = "{const a = b.trim();}".to_string();
         let js_file = "test.js".to_string();

--- a/src/tests/string_method_test.rs
+++ b/src/tests/string_method_test.rs
@@ -95,17 +95,17 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code).contains("let __datadog_test_0, __datadog_test_1;
-    const a = (__datadog_test_0 = b, __datadog_test_1 = String.prototype.substring, _ddiast.stringSubstring(__datadog_test_1.call(__datadog_test_0, 2), __datadog_test_1, __datadog_test_0, 2));");
+    const a = (__datadog_test_0 = b, __datadog_test_1 = String.prototype.substring, _ddiast.stringSubstring(__datadog_test_1.apply(__datadog_test_0, [\n        2\n    ]), __datadog_test_1, __datadog_test_0, 2));");
         Ok(())
     }
 
     #[test]
     fn test_prototype_substring_apply_with_call_arg() -> Result<(), String> {
-        let original_code = "{const a = String.prototype.substring.apply(b(), [2]);}".to_string();
+        let original_code = "{const a = String.prototype.substring.apply(b(), [c]);}".to_string();
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
-        assert_that(&rewritten.code).contains("let __datadog_test_0, __datadog_test_1;
-    const a = (__datadog_test_0 = b(), __datadog_test_1 = String.prototype.substring, _ddiast.stringSubstring(__datadog_test_1.call(__datadog_test_0, 2), __datadog_test_1, __datadog_test_0, 2));");
+        assert_that(&rewritten.code).contains("let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+    const a = (__datadog_test_0 = b(), __datadog_test_1 = String.prototype.substring, __datadog_test_2 = c, _ddiast.stringSubstring(__datadog_test_1.apply(__datadog_test_0, [\n        __datadog_test_2\n    ]), __datadog_test_1, __datadog_test_0, __datadog_test_2));");
         Ok(())
     }
 
@@ -130,11 +130,29 @@ mod tests {
     }
 
     #[test]
+    fn test_prototype_concat_call_this_spread() -> Result<(), String> {
+        let original_code = "{const c = String.prototype.concat.call(...a)}".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.stringConcat(__datadog_test_0.call(...__datadog_test_1), __datadog_test_0, ...__datadog_test_1));");
+        Ok(())
+    }
+
+    #[test]
     fn test_prototype_concat_call_args_spread() -> Result<(), String> {
         let original_code = "{const c = String.prototype.concat.call(a, ...b)}".to_string();
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = b, _ddiast.stringConcat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
+        Ok(())
+    }
+
+    #[test]
+    fn test_prototype_concat_apply_args_spread() -> Result<(), String> {
+        let original_code = "{const c = String.prototype.concat.apply(a, ...b)}".to_string();
+        let js_file = "test.js".to_string();
+        let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
+        assert_that(&rewritten.code).contains("const c = (__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, __datadog_test_2 = b, _ddiast.stringConcat(__datadog_test_1.apply(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0, ...__datadog_test_2));");
         Ok(())
     }
 

--- a/src/transform/binary_add_transform.rs
+++ b/src/transform/binary_add_transform.rs
@@ -75,6 +75,7 @@ fn prepare_replace_expressions_in_binary(
         &binary.span,
         ident_provider,
         false,
+        false,
     );
 
     let right_ident_mode = DefaultOperandHandler::get_ident_mode(&mut binary.left);
@@ -85,6 +86,7 @@ fn prepare_replace_expressions_in_binary(
         arguments,
         &binary.span,
         ident_provider,
+        false,
         false,
     );
 

--- a/src/transform/binary_add_transform.rs
+++ b/src/transform/binary_add_transform.rs
@@ -63,33 +63,35 @@ fn to_dd_binary_expr_binary(
 fn prepare_replace_expressions_in_binary(
     binary: &mut BinExpr,
     assignations: &mut Vec<Expr>,
-    arguments: &mut Vec<Expr>,
+    arguments: &mut Vec<ExprOrSpread>,
     ident_provider: &mut dyn IdentProvider,
 ) -> bool {
     let left_ident_mode = DefaultOperandHandler::get_ident_mode(&mut binary.right);
-    DefaultOperandHandler::replace_expressions_in_operand(
+    DefaultOperandHandler::replace_expressions_in_expr(
         &mut binary.left,
         left_ident_mode,
         assignations,
         arguments,
         &binary.span,
         ident_provider,
+        false,
     );
 
     let right_ident_mode = DefaultOperandHandler::get_ident_mode(&mut binary.left);
-    DefaultOperandHandler::replace_expressions_in_operand(
+    DefaultOperandHandler::replace_expressions_in_expr(
         &mut binary.right,
         right_ident_mode,
         assignations,
         arguments,
         &binary.span,
         ident_provider,
+        false,
     );
 
     // if all arguments are literals we can skip expression replacement
     must_replace_binary_expression(arguments)
 }
 
-fn must_replace_binary_expression(arguments: &[Expr]) -> bool {
-    arguments.iter().any(|arg| !matches!(arg, Expr::Lit(_)))
+fn must_replace_binary_expression(arguments: &[ExprOrSpread]) -> bool {
+    arguments.iter().any(|arg| !arg.expr.is_lit())
 }

--- a/src/transform/binary_add_transform.rs
+++ b/src/transform/binary_add_transform.rs
@@ -7,11 +7,13 @@ use swc_ecma_ast::*;
 use crate::{
     transform::operand_handler::{DefaultOperandHandler, OperandHandler},
     visitor::{
-        csi_methods::CsiMethods, ident_provider::IdentProvider, visitor_util::get_dd_paren_expr,
+        csi_methods::CsiMethods,
+        ident_provider::{IdentKind, IdentProvider},
+        visitor_util::get_dd_paren_expr,
     },
 };
 
-use super::transform_status::TransformResult;
+use super::{operand_handler::ExpandArrays, transform_status::TransformResult};
 
 pub struct BinaryAddTransform {}
 
@@ -74,8 +76,8 @@ fn prepare_replace_expressions_in_binary(
         arguments,
         &binary.span,
         ident_provider,
-        false,
-        false,
+        IdentKind::Expr,
+        ExpandArrays::No,
     );
 
     let right_ident_mode = DefaultOperandHandler::get_ident_mode(&mut binary.left);
@@ -86,8 +88,8 @@ fn prepare_replace_expressions_in_binary(
         arguments,
         &binary.span,
         ident_provider,
-        false,
-        false,
+        IdentKind::Expr,
+        ExpandArrays::No,
     );
 
     // if all arguments are literals we can skip expression replacement

--- a/src/transform/call_expr_transform.rs
+++ b/src/transform/call_expr_transform.rs
@@ -198,19 +198,19 @@ fn replace_call_expr_if_csi_method_without_callee(
             // let __datadog_test_0;
             // (__datadog_test_0 = arg0, _ddiast.aloneMethod
             // (aloneMethod(__datadog_test_0), aloneMethod, undefined, __datadog_test_0));
-            arguments.push(Expr::Ident(ident.clone()));
+            arguments.push(ExprOrSpread::from(Expr::Ident(ident.clone())));
             let global = Ident {
                 span,
                 sym: JsWord::from("undefined"),
                 optional: false,
                 ctxt: SyntaxContext::empty(),
             };
-            arguments.push(Expr::Ident(global));
+            arguments.push(ExprOrSpread::from(Expr::Ident(global)));
 
             let mut call_replacement = call.clone();
             call_replacement.args.iter_mut().for_each(|expr_or_spread| {
-                DefaultOperandHandler::replace_expressions_in_operand(
-                    &mut expr_or_spread.expr,
+                DefaultOperandHandler::replace_expressions_in_expr_or_spread(
+                    expr_or_spread,
                     IdentMode::Replace,
                     &mut assignations,
                     &mut arguments,
@@ -268,6 +268,7 @@ fn replace_call_expr_if_csi_method_with_member(
                     &mut assignations,
                     &mut arguments,
                     &span,
+                    false,
                 )
             }
             None => {
@@ -284,11 +285,12 @@ fn replace_call_expr_if_csi_method_with_member(
                     &mut assignations,
                     &mut arguments,
                     &span,
+                    false,
                 )
             }
         };
 
-        arguments.push(ident_replacement.clone());
+        arguments.push(ExprOrSpread::from(ident_replacement.clone()));
 
         // change callee to __datadog_token_$i2.call
         call_replacement.callee = Callee::Expr(Box::new(Expr::Member(MemberExpr {
@@ -298,8 +300,8 @@ fn replace_call_expr_if_csi_method_with_member(
         })));
 
         call_replacement.args.iter_mut().for_each(|expr_or_spread| {
-            DefaultOperandHandler::replace_expressions_in_operand(
-                &mut expr_or_spread.expr,
+            DefaultOperandHandler::replace_expressions_in_expr_or_spread(
+                expr_or_spread,
                 IdentMode::Replace,
                 &mut assignations,
                 &mut arguments,

--- a/src/transform/call_expr_transform.rs
+++ b/src/transform/call_expr_transform.rs
@@ -254,8 +254,12 @@ fn replace_call_expr_if_csi_method_with_member(
         //  b) String.prototype.substring.[call|apply](a) -> __datadog_token_$i = a, __datadog_token_$i2 = String.prototype.substring, __datadog_token_$i2.call(__datadog_token_$i, __datadog_token_$i2)
 
         // __datadog_token_$i = a
-        let ident_replacement_option =
-            ident_provider.get_temporal_ident_used_in_assignation(expr, &mut assignations, &span);
+        let ident_replacement_option = ident_provider.get_temporal_ident_used_in_assignation(
+            expr,
+            &mut assignations,
+            &span,
+            false,
+        );
 
         let ident_replacement = ident_replacement_option.map_or_else(|| expr.clone(), Expr::Ident);
 

--- a/src/transform/call_expr_transform.rs
+++ b/src/transform/call_expr_transform.rs
@@ -152,12 +152,13 @@ fn replace_prototype_call_or_apply(
     );
 
     match prototype_call_option {
-        Some(mut prototype_call) => replace_call_expr_if_csi_method_with_member(
+        Some(mut prototype_call) => replace_call_expr_or_spread_if_csi_method_with_member(
             &prototype_call.0,
             &prototype_call.1.into(),
             &mut prototype_call.2,
             csi_methods,
-            Some(member),
+            member,
+            &ident_name.sym,
             ident_provider,
         ),
         _ => None,
@@ -176,6 +177,7 @@ fn replace_call_expr_if_csi_method(
         ident_name,
         call,
         csi_methods,
+        None,
         None,
         ident_provider,
     )
@@ -207,17 +209,14 @@ fn replace_call_expr_if_csi_method_without_callee(
             };
             arguments.push(ExprOrSpread::from(Expr::Ident(global)));
 
-            let mut call_replacement = call.clone();
-            call_replacement.args.iter_mut().for_each(|expr_or_spread| {
-                DefaultOperandHandler::replace_expressions_in_expr_or_spread(
-                    expr_or_spread,
-                    IdentMode::Replace,
-                    &mut assignations,
-                    &mut arguments,
-                    &span,
-                    ident_provider,
-                )
-            });
+            let call_replacement = replace_call_callee_and_args(
+                call,
+                None,
+                &mut assignations,
+                &mut arguments,
+                None,
+                ident_provider,
+            );
 
             return Some(ResultExpr {
                 tag: method_name.clone(),
@@ -240,6 +239,7 @@ fn replace_call_expr_if_csi_method_with_member(
     call: &mut CallExpr,
     csi_methods: &CsiMethods,
     member_expr_opt: Option<&MemberExpr>,
+    call_or_apply: Option<&str>,
     ident_provider: &mut dyn IdentProvider,
 ) -> Option<ResultExpr> {
     let method_name = &ident_name.sym.to_string();
@@ -252,7 +252,6 @@ fn replace_call_expr_if_csi_method_with_member(
         // replace original call expression with a parent expression splitting every component and finally invoking .call
         //  a) a.substring() -> __datadog_token_$i = a, __datadog_token_$i2 = __datadog_token_$i.substring, __datadog_token_$i2.call(__datadog_token_$i, __datadog_token_$i2)
         //  b) String.prototype.substring.[call|apply](a) -> __datadog_token_$i = a, __datadog_token_$i2 = String.prototype.substring, __datadog_token_$i2.call(__datadog_token_$i, __datadog_token_$i2)
-        let mut call_replacement = call.clone();
 
         // __datadog_token_$i = a
         let ident_replacement_option =
@@ -292,23 +291,14 @@ fn replace_call_expr_if_csi_method_with_member(
 
         arguments.push(ExprOrSpread::from(ident_replacement.clone()));
 
-        // change callee to __datadog_token_$i2.call
-        call_replacement.callee = Callee::Expr(Box::new(Expr::Member(MemberExpr {
-            span,
-            obj: Box::new(ident_callee.map_or_else(|| expr.clone(), Expr::Ident)),
-            prop: MemberProp::Ident(IdentName::new(JsWord::from("call"), span)),
-        })));
-
-        call_replacement.args.iter_mut().for_each(|expr_or_spread| {
-            DefaultOperandHandler::replace_expressions_in_expr_or_spread(
-                expr_or_spread,
-                IdentMode::Replace,
-                &mut assignations,
-                &mut arguments,
-                &span,
-                ident_provider,
-            )
-        });
+        let mut call_replacement = replace_call_callee_and_args(
+            call,
+            Some(ident_callee.map_or_else(|| expr.clone(), Expr::Ident)),
+            &mut assignations,
+            &mut arguments,
+            call_or_apply,
+            ident_provider,
+        );
 
         // insert .call(this) argument
         call_replacement.args.insert(
@@ -331,4 +321,125 @@ fn replace_call_expr_if_csi_method_with_member(
         });
     }
     None
+}
+
+fn replace_call_expr_or_spread_if_csi_method_with_member(
+    expr_or_spread: &ExprOrSpread,
+    ident_name: &IdentName,
+    call: &mut CallExpr,
+    csi_methods: &CsiMethods,
+    member_expr: &MemberExpr,
+    call_or_apply: &str,
+    ident_provider: &mut dyn IdentProvider,
+) -> Option<ResultExpr> {
+    if expr_or_spread.spread.is_none() {
+        //  String.prototype.concat.call(a, b) or a.concat(b)
+        replace_call_expr_if_csi_method_with_member(
+            &expr_or_spread.expr,
+            ident_name,
+            call,
+            csi_methods,
+            Some(member_expr),
+            Some(call_or_apply),
+            ident_provider,
+        )
+    } else {
+        //  String.prototype.concat.call(...a, b)
+        replace_call_spread_if_csi_method_with_member(
+            ident_name,
+            call,
+            csi_methods,
+            member_expr,
+            call_or_apply,
+            ident_provider,
+        )
+    }
+}
+
+fn replace_call_spread_if_csi_method_with_member(
+    ident_name: &IdentName,
+    call: &mut CallExpr,
+    csi_methods: &CsiMethods,
+    member_expr: &MemberExpr,
+    call_or_apply: &str,
+    ident_provider: &mut dyn IdentProvider,
+) -> Option<ResultExpr> {
+    let method_name = &ident_name.sym.to_string();
+
+    if let Some(csi_method) = csi_methods.get(method_name) {
+        let mut assignations = Vec::new();
+        let mut arguments = Vec::new();
+        let span = call.span;
+
+        // __datadog_token_$i2 = member
+        let ident_callee = ident_provider.get_ident_used_in_assignation(
+            &Expr::Member(member_expr.clone()),
+            &mut assignations,
+            &mut arguments,
+            &span,
+            false,
+        );
+
+        // return if there is no ident_callee
+        ident_callee.as_ref()?;
+
+        let call_replacement = replace_call_callee_and_args(
+            call,
+            Some(Expr::Ident(ident_callee.unwrap())),
+            &mut assignations,
+            &mut arguments,
+            Some(call_or_apply),
+            ident_provider,
+        );
+
+        return Some(ResultExpr {
+            tag: method_name.clone(),
+            expr: get_dd_paren_expr(
+                &Expr::Call(call_replacement),
+                &arguments,
+                &mut assignations,
+                csi_method.dst.as_str(),
+                &span,
+            ),
+        });
+    }
+    None
+}
+
+fn replace_call_callee_and_args(
+    call: &mut CallExpr,
+    ident_callee_expr: Option<Expr>,
+    assignations: &mut Vec<Expr>,
+    arguments: &mut Vec<ExprOrSpread>,
+    call_or_apply: Option<&str>,
+    ident_provider: &mut dyn IdentProvider,
+) -> CallExpr {
+    let mut call_replacement = call.clone();
+
+    let span = call.span;
+
+    let prop_name = call_or_apply.unwrap_or("call");
+
+    // change callee to __datadog_token_$i2.[call|apply]
+    if let Some(ident) = ident_callee_expr {
+        call_replacement.callee = Callee::Expr(Box::new(Expr::Member(MemberExpr {
+            span,
+            obj: Box::new(ident),
+            prop: MemberProp::Ident(IdentName::new(prop_name.into(), span)),
+        })));
+    }
+
+    call_replacement.args.iter_mut().for_each(|expr_or_spread| {
+        DefaultOperandHandler::replace_expressions_in_expr_or_spread(
+            expr_or_spread,
+            IdentMode::Replace,
+            assignations,
+            arguments,
+            &span,
+            ident_provider,
+            prop_name == "apply",
+        )
+    });
+
+    call_replacement
 }

--- a/src/transform/function_prototype_transform.rs
+++ b/src/transform/function_prototype_transform.rs
@@ -60,7 +60,8 @@ impl FunctionPrototypeTransform {
             }
 
             let method_ident = path_parts[0].clone();
-            let this_expr = &call.args[0].expr;
+            let this_expr_or_spread = &call.args[0];
+            let this_expr = &this_expr_or_spread.expr;
 
             if this_expr.is_lit()
                 && (!csi_methods.method_allows_literal_callers(&method_ident.sym)

--- a/src/transform/function_prototype_transform.rs
+++ b/src/transform/function_prototype_transform.rs
@@ -28,9 +28,9 @@ impl FunctionPrototypeTransform {
 
     /// inspects call expression searching for $class_name.prototype.$method_name.[call|apply]($this_expr, $arguments) and if there is a match
     /// returns a tuple (
-    ///     Expr -> $this_expr,
+    ///     ExprOrSpread -> $this_expr,
     ///     Ident -> $method_name,
-    ///     CallExpr -> a expression equivalent to $this_expr.$method_name($arguments)
+    ///     CallExpr -> an expression equivalent to $this_expr.$method_name($arguments)
     /// )
     ///
     pub fn get_expression_parts_from_call_or_apply(
@@ -38,29 +38,36 @@ impl FunctionPrototypeTransform {
         member: &MemberExpr,
         ident_name: &IdentName,
         csi_methods: &CsiMethods,
-    ) -> Option<(Expr, Ident, CallExpr)> {
+    ) -> Option<(ExprOrSpread, Ident, CallExpr)> {
         if !Self::is_call_or_apply(ident_name) {
             return None;
         }
 
-        let method_name = ident_name.sym.to_string();
         let mut path_parts = vec![];
         if get_prototype_member_path(member, &mut path_parts) {
             if call.args.is_empty() {
                 return None;
             }
 
-            let mut filtered_args = vec![];
-            if !filter_call_args(
-                &call.args,
-                method_name == APPLY_METHOD_NAME,
-                &mut filtered_args,
-            ) {
+            let method_ident = path_parts[0].clone();
+            let this_expr_or_spread = &call.args[0];
+
+            // ...$this_expr - we can not return an Expr for an spread expression
+            if this_expr_or_spread.spread.is_some() {
+                return Some((this_expr_or_spread.clone(), method_ident, call.clone()));
+            }
+
+            if invalid_args(ident_name, call) {
                 return None;
             }
 
-            let method_ident = path_parts[0].clone();
-            let this_expr_or_spread = &call.args[0];
+            let filtered_args = call
+                .args
+                .iter()
+                .skip(1)
+                .cloned()
+                .collect::<Vec<ExprOrSpread>>();
+
             let this_expr = &this_expr_or_spread.expr;
 
             if this_expr.is_lit()
@@ -87,40 +94,15 @@ impl FunctionPrototypeTransform {
                 ctxt: SyntaxContext::empty(),
             };
 
-            return Some((*this_expr.clone(), method_ident, new_call));
+            return Some((
+                ExprOrSpread::from(*this_expr.clone()),
+                method_ident,
+                new_call,
+            ));
         }
 
         None
     }
-}
-
-fn filter_call_args(
-    args: &[ExprOrSpread],
-    is_apply: bool,
-    filtered_args: &mut Vec<ExprOrSpread>,
-) -> bool {
-    // when using apply, arguments are provided as an array
-    let mut success_filtering = true;
-    if is_apply {
-        if args.len() >= 2 {
-            if args[1].expr.is_array() {
-                let array = args[1].expr.as_array().unwrap();
-                filtered_args.append(
-                    &mut array
-                        .elems
-                        .iter()
-                        .filter(|elem| elem.is_some())
-                        .map(|elem| elem.as_ref().unwrap().clone())
-                        .collect(),
-                );
-            } else {
-                success_filtering = false;
-            }
-        }
-    } else {
-        filtered_args.append(&mut args.iter().skip(1).cloned().collect::<Vec<ExprOrSpread>>());
-    }
-    success_filtering
 }
 
 fn get_prototype_member_path(member: &MemberExpr, parts: &mut Vec<Ident>) -> bool {
@@ -145,4 +127,32 @@ fn all_args_are_literal(args: &[ExprOrSpread]) -> bool {
 
 fn is_undefined_or_null(expr: &Expr) -> bool {
     expr.is_ident_ref_to("undefined") || expr.is_ident_ref_to("null")
+}
+
+fn invalid_args(ident_name: &IdentName, call: &CallExpr) -> bool {
+    let name = ident_name.sym.to_string();
+    if name != "apply" {
+        return false;
+    }
+
+    if call.args.len() >= 2 {
+        let this = &call.args[0];
+        let args_array = &call.args[1];
+        if args_array.expr.is_array() {
+            let array = args_array.expr.as_array().unwrap();
+            return this.expr.is_lit()
+                && array.elems.iter().skip(1).all(|elem| {
+                    if elem.is_none() {
+                        return false;
+                    }
+
+                    let expr_or_spread = elem.as_ref().unwrap();
+                    expr_or_spread.expr.is_lit() || is_undefined_or_null(&expr_or_spread.expr)
+                });
+        } else if args_array.spread.is_some() {
+            return false;
+        }
+    }
+
+    true
 }

--- a/src/transform/operand_handler.rs
+++ b/src/transform/operand_handler.rs
@@ -3,6 +3,7 @@
  * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
  **/
 use swc_common::{util::take::Take, Span};
+use swc_ecma_ast::ExprOrSpread;
 use swc_ecma_visit::swc_ecma_ast::{BinaryOp, Expr};
 
 use crate::visitor::ident_provider::IdentProvider;
@@ -14,41 +15,73 @@ pub enum IdentMode {
 }
 
 pub trait OperandHandler {
-    fn replace_expressions_in_operand(
-        operand: &mut Expr,
+    fn replace_expressions_in_expr_or_spread(
+        operand: &mut ExprOrSpread,
         ident_mode: IdentMode,
         assignations: &mut Vec<Expr>,
-        arguments: &mut Vec<Expr>,
+        arguments: &mut Vec<ExprOrSpread>,
         span: &Span,
         ident_provider: &mut dyn IdentProvider,
     ) {
-        match operand {
-            Expr::Lit(_) => Self::replace_literals(operand, arguments),
+        let is_spread = operand.spread.is_some();
+        let operand_expr = &mut *operand.expr;
+
+        Self::replace_expressions_in_expr(
+            operand_expr,
+            ident_mode,
+            assignations,
+            arguments,
+            span,
+            ident_provider,
+            is_spread,
+        )
+    }
+
+    fn replace_expressions_in_expr(
+        expr: &mut Expr,
+        ident_mode: IdentMode,
+        assignations: &mut Vec<Expr>,
+        arguments: &mut Vec<ExprOrSpread>,
+        span: &Span,
+        ident_provider: &mut dyn IdentProvider,
+        is_spread: bool,
+    ) {
+        match expr {
+            Expr::Lit(_) => Self::replace_literals(expr, arguments),
             Expr::Ident(_) => {
                 if ident_mode == IdentMode::Replace {
-                    operand.map_with_mut(|op| {
-                        let ident = ident_provider.get_ident_used_in_assignation(
-                            &op,
-                            assignations,
-                            arguments,
-                            span,
-                        );
-
-                        ident.map_or(op, Expr::Ident)
+                    expr.map_with_mut(|op| {
+                        ident_provider
+                            .get_ident_used_in_assignation(
+                                &op,
+                                assignations,
+                                arguments,
+                                span,
+                                is_spread,
+                            )
+                            .map_or(op, Expr::Ident)
                     })
                 } else {
-                    arguments.push(operand.clone())
+                    arguments.push(ExprOrSpread::from(expr.clone()))
                 }
             }
             Expr::Bin(ref binary) => Self::replace_binary(
                 binary.op,
-                operand,
+                expr,
                 assignations,
                 arguments,
                 span,
                 ident_provider,
+                is_spread,
             ),
-            _ => Self::replace_default(operand, assignations, arguments, span, ident_provider),
+            _ => Self::replace_default(
+                expr,
+                assignations,
+                arguments,
+                span,
+                ident_provider,
+                is_spread,
+            ),
         }
     }
 
@@ -60,22 +93,22 @@ pub trait OperandHandler {
         }
     }
 
-    fn replace_literals(operand: &mut Expr, arguments: &mut Vec<Expr>) {
-        arguments.push(operand.clone())
+    fn replace_literals(operand: &mut Expr, arguments: &mut Vec<ExprOrSpread>) {
+        arguments.push(ExprOrSpread::from(operand.clone()))
     }
 
     fn replace_default(
         operand: &mut Expr,
         assignations: &mut Vec<Expr>,
-        arguments: &mut Vec<Expr>,
+        arguments: &mut Vec<ExprOrSpread>,
         span: &Span,
         ident_provider: &mut dyn IdentProvider,
+        is_spread: bool,
     ) {
         operand.map_with_mut(|op| {
-            let ident =
-                ident_provider.get_ident_used_in_assignation(&op, assignations, arguments, span);
-
-            ident.map_or(op, Expr::Ident)
+            ident_provider
+                .get_ident_used_in_assignation(&op, assignations, arguments, span, is_spread)
+                .map_or(op, Expr::Ident)
         })
     }
 
@@ -83,12 +116,20 @@ pub trait OperandHandler {
         binary_op: BinaryOp,
         operand: &mut Expr,
         assignations: &mut Vec<Expr>,
-        arguments: &mut Vec<Expr>,
+        arguments: &mut Vec<ExprOrSpread>,
         span: &Span,
         ident_provider: &mut dyn IdentProvider,
+        is_spread: bool,
     ) {
         if binary_op != BinaryOp::Add {
-            Self::replace_default(operand, assignations, arguments, span, ident_provider);
+            Self::replace_default(
+                operand,
+                assignations,
+                arguments,
+                span,
+                ident_provider,
+                is_spread,
+            );
         }
     }
 }

--- a/src/transform/operand_handler.rs
+++ b/src/transform/operand_handler.rs
@@ -76,7 +76,7 @@ pub trait OperandHandler {
                             .map_or(op, Expr::Ident)
                     })
                 } else {
-                    arguments.push(ExprOrSpread::from(expr.clone()))
+                    arguments.push(ident_provider.get_expr_or_spread(expr, ident_kind))
                 }
             }
             Expr::Bin(ref binary) => Self::replace_binary(

--- a/src/visitor/ident_provider.rs
+++ b/src/visitor/ident_provider.rs
@@ -6,7 +6,8 @@ use std::collections::HashSet;
 use swc::atoms::JsWord;
 use swc_common::{Span, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::{
-    AssignExpr, AssignOp, AssignTarget, BindingIdent, Expr, ExprOrSpread, Ident, SimpleAssignTarget,
+    ArrayLit, AssignExpr, AssignOp, AssignTarget, BindingIdent, Expr, ExprOrSpread, Ident,
+    SimpleAssignTarget,
 };
 
 use super::visitor_util::get_dd_local_variable_name;
@@ -20,7 +21,8 @@ pub trait IdentProvider {
         span: &Span,
         is_spread: bool,
     ) -> Option<Ident> {
-        let id = self.get_temporal_ident_used_in_assignation(operand, assignations, span);
+        let id =
+            self.get_temporal_ident_used_in_assignation(operand, assignations, span, is_spread);
 
         let id_expr = id
             .as_ref()
@@ -42,13 +44,14 @@ pub trait IdentProvider {
         operand: &Expr,
         assignations: &mut Vec<Expr>,
         span: &Span,
+        is_spread: bool,
     ) -> Option<Ident> {
         if operand.is_lit() {
             return None;
         }
 
         let next_ident = self.next_ident();
-        let (assign, id) = self.create_assign_expression(next_ident, operand, span);
+        let (assign, id) = self.create_assign_expression(next_ident, operand, span, is_spread);
 
         // store ident and assignation expression
         self.register_ident(id.clone());
@@ -63,6 +66,7 @@ pub trait IdentProvider {
         index: usize,
         expr: &Expr,
         span: &Span,
+        is_spread: bool,
     ) -> (AssignExpr, Ident) {
         let id = Ident {
             span: DUMMY_SP,
@@ -80,11 +84,34 @@ pub trait IdentProvider {
                     id: id.clone(),
                     type_ann: None,
                 })),
-                right: Box::new(expr.clone()),
+                right: self.create_assign_right_operand_expression(expr, is_spread),
                 op: AssignOp::Assign,
             },
             id,
         )
+    }
+
+    fn create_assign_right_operand_expression(
+        &mut self,
+        expr: &Expr,
+        is_spread: bool,
+    ) -> Box<Expr> {
+        // when is_spread, create a new array with the spread expression [...a] to avoid spreading it twice.
+        // 'a' could be a Proxy which intercepts the get and does some operation on every call
+        // (__datadog_test_0 = "hello".concat, __datadog_test_1 = [...a], _ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello", ...__datadog_test_1))
+        let right_ep = if is_spread {
+            Expr::Array(ArrayLit {
+                span: DUMMY_SP,
+                elems: vec![Some(ExprOrSpread {
+                    spread: Some(DUMMY_SP),
+                    expr: Box::new(expr.clone()),
+                })],
+            })
+        } else {
+            expr.clone()
+        };
+
+        Box::new(right_ep)
     }
 
     fn register_ident(&mut self, ident: Ident);

--- a/src/visitor/ident_provider.rs
+++ b/src/visitor/ident_provider.rs
@@ -43,16 +43,7 @@ pub trait IdentProvider {
             .map_or_else(|| operand.clone(), |ident| Expr::Ident(ident.clone()));
 
         // store ident as argument
-        let spread = if ident_kind == IdentKind::Spread {
-            Some(DUMMY_SP)
-        } else {
-            None
-        };
-
-        arguments.push(ExprOrSpread {
-            spread,
-            expr: Box::new(id_expr.clone()),
-        });
+        arguments.push(self.get_expr_or_spread(&id_expr, ident_kind));
 
         id
     }
@@ -130,6 +121,19 @@ pub trait IdentProvider {
         };
 
         Box::new(right_ep)
+    }
+
+    fn get_expr_or_spread(&mut self, expr: &Expr, ident_kind: IdentKind) -> ExprOrSpread {
+        let spread = if ident_kind == IdentKind::Spread {
+            Some(DUMMY_SP)
+        } else {
+            None
+        };
+
+        ExprOrSpread {
+            spread,
+            expr: Box::new(expr.clone()),
+        }
     }
 
     fn register_ident(&mut self, ident: Ident);

--- a/src/visitor/ident_provider.rs
+++ b/src/visitor/ident_provider.rs
@@ -18,14 +18,6 @@ pub enum IdentKind {
     Spread,
 }
 
-impl From<ExprOrSpread> for IdentKind {
-    fn from(expr_or_spread: ExprOrSpread) -> Self {
-        expr_or_spread
-            .spread
-            .map_or_else(|| IdentKind::Expr, |_| IdentKind::Spread)
-    }
-}
-
 pub trait IdentProvider {
     fn get_ident_used_in_assignation(
         &mut self,
@@ -105,7 +97,7 @@ pub trait IdentProvider {
         expr: &Expr,
         ident_kind: IdentKind,
     ) -> Box<Expr> {
-        // when is_spread, create a new array with the spread expression [...a] to avoid spreading it twice.
+        // when IdentKind::Spread, create a new array with the spread expression [...a] to avoid spreading it twice.
         // 'a' could be a Proxy which intercepts the get and does some operation on every call
         // (__datadog_test_0 = "hello".concat, __datadog_test_1 = [...a], _ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello", ...__datadog_test_1))
         let right_ep = if ident_kind == IdentKind::Spread {

--- a/src/visitor/visitor_util.rs
+++ b/src/visitor/visitor_util.rs
@@ -31,21 +31,18 @@ pub fn dd_global_method_invocation(method_name: &str, span: &Span) -> Callee {
     })))
 }
 
-pub fn get_dd_call_expr(expr: &Expr, arguments: &[Expr], method_name: &str, span: &Span) -> Expr {
+pub fn get_dd_call_expr(
+    expr: &Expr,
+    arguments: &[ExprOrSpread],
+    method_name: &str,
+    span: &Span,
+) -> Expr {
     let mut args: Vec<ExprOrSpread> = vec![ExprOrSpread {
         expr: Box::new(expr.clone()),
         spread: None,
     }];
 
-    args.append(
-        &mut arguments
-            .iter()
-            .map(|expr| ExprOrSpread {
-                expr: Box::new(expr.clone()),
-                spread: None,
-            })
-            .collect::<Vec<_>>(),
-    );
+    args.append(&mut arguments.to_vec());
 
     Expr::Call(CallExpr {
         span: *span,
@@ -58,7 +55,7 @@ pub fn get_dd_call_expr(expr: &Expr, arguments: &[Expr], method_name: &str, span
 
 pub fn get_dd_paren_expr(
     expr: &Expr,
-    arguments: &[Expr],
+    arguments: &[ExprOrSpread],
     assignations: &mut Vec<Expr>,
     method_name: &str,
     span: &Span,

--- a/test/string_method.spec.js
+++ b/test/string_method.spec.js
@@ -278,7 +278,7 @@ _ddiast.concat(__datadog_test_0.apply("hello", [\n"world",\n__datadog_test_1\n])
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1;
-        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = [\n        ...a\n    ], _ddiast.concat(\
 __datadog_test_0.call(...__datadog_test_1), __datadog_test_0, ...__datadog_test_1));`)
         )
       })
@@ -289,9 +289,9 @@ __datadog_test_0.call(...__datadog_test_1), __datadog_test_0, ...__datadog_test_
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, __datadog_test_2 = b, _ddiast.concat(\
-__datadog_test_0.call(...__datadog_test_1, ...__datadog_test_2), __datadog_test_0, ...__datadog_test_1, \
-...__datadog_test_2));`)
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = [\n        ...a\n    ], \
+__datadog_test_2 = [\n        ...b\n    ], _ddiast.concat(__datadog_test_0.call(...__datadog_test_1, \
+...__datadog_test_2), __datadog_test_0, ...__datadog_test_1, ...__datadog_test_2));`)
         )
       })
 
@@ -301,7 +301,7 @@ __datadog_test_0.call(...__datadog_test_1, ...__datadog_test_2), __datadog_test_
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1;
-        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = [\n        ...a\n    ], _ddiast.concat(\
 __datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello", ...__datadog_test_1));`)
         )
       })
@@ -312,9 +312,9 @@ __datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello", 
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, __datadog_test_2 = b, \
-_ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1, ...__datadog_test_2), __datadog_test_0\
-, "hello", ...__datadog_test_1, ...__datadog_test_2));`)
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = \
+[\n        ...a\n    ], __datadog_test_2 = [\n        ...b\n    ], _ddiast.concat(__datadog_test_0.call("hello", \
+...__datadog_test_1, ...__datadog_test_2), __datadog_test_0, "hello", ...__datadog_test_1, ...__datadog_test_2));`)
         )
       })
 
@@ -324,7 +324,7 @@ _ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1, ...__datadog_
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1;
-        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = [\n        ...a\n    ], _ddiast.concat(\
 __datadog_test_0.apply("hello", ...__datadog_test_1), __datadog_test_0, "hello", ...__datadog_test_1));`)
         )
       })
@@ -335,7 +335,7 @@ __datadog_test_0.apply("hello", ...__datadog_test_1), __datadog_test_0, "hello",
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1;
-        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = [\n        ...a\n    ], _ddiast.concat(\
 __datadog_test_0.apply(...__datadog_test_1), __datadog_test_0, ...__datadog_test_1));`)
         )
       })
@@ -346,9 +346,9 @@ __datadog_test_0.apply(...__datadog_test_1), __datadog_test_0, ...__datadog_test
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-        return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.concat(\
-__datadog_test_1.call(__datadog_test_0, "world", ...__datadog_test_2), __datadog_test_1, __datadog_test_0\
-, "world", ...__datadog_test_2));`)
+        return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = \
+[\n        ...b\n    ], _ddiast.concat(__datadog_test_1.call(__datadog_test_0, "world", ...__datadog_test_2)\
+, __datadog_test_1, __datadog_test_0, "world", ...__datadog_test_2));`)
         )
       })
 
@@ -358,9 +358,9 @@ __datadog_test_1.call(__datadog_test_0, "world", ...__datadog_test_2), __datadog
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
-        return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.concat(\
-__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0\
-, ...__datadog_test_2));`)
+        return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = \
+[\n        ...b\n    ], _ddiast.concat(__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), \
+__datadog_test_1, __datadog_test_0, ...__datadog_test_2));`)
         )
       })
 
@@ -370,7 +370,7 @@ __datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, 
         rewriteAndExpectAndExpectEval(
           js,
           builder.build(`let __datadog_test_0, __datadog_test_1;
-        return (__datadog_test_0 = "hello".concat, __datadog_test_1 = a, _ddiast.concat(\
+        return (__datadog_test_0 = "hello".concat, __datadog_test_1 = [\n...a\n], _ddiast.concat(\
 __datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello"\
 , ...__datadog_test_1));`)
         )

--- a/test/string_method.spec.js
+++ b/test/string_method.spec.js
@@ -258,6 +258,43 @@ _ddiast.concat(__datadog_test_0.call("hello", "world", __datadog_test_1), __data
       }`
       )
     })
+
+    describe('spread arguments', () => {
+      it('does modify String.prototype.concat.call("hello", ...a)', () => {
+        const builder = fn().args([' ', 'heLLo', ' ', 'world'])
+        const js = builder.build('return String.prototype.concat.call("hello", ...a)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1;
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+__datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello", ...__datadog_test_1));`)
+        )
+      })
+
+      it('does modify String.prototype.concat.call("hello", ...a, ...b)', () => {
+        const builder = fn().args([' ', 'heLLo', ' ', 'world'], ['bye', 'world'])
+        const js = builder.build('return String.prototype.concat.call("hello", ...a, ...b)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, __datadog_test_2 = b, \
+_ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1, ...__datadog_test_2), __datadog_test_0\
+, "hello", ...__datadog_test_1, ...__datadog_test_2));`)
+        )
+      })
+
+      it('does modify a.concat("world", ...b)', () => {
+        const builder = fn().args('hello', [' ', 'bye', ' ', 'world'])
+        const js = builder.build('return a.concat("world", ...b)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+        return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.concat(\
+__datadog_test_1.call(__datadog_test_0, "world", ...__datadog_test_2), __datadog_test_1, __datadog_test_0\
+, "world", ...__datadog_test_2));`)
+        )
+      })
+    })
   })
 
   const methodAllowingLiterals = ['concat', 'replace']

--- a/test/string_method.spec.js
+++ b/test/string_method.spec.js
@@ -375,6 +375,18 @@ __datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello"\
 , ...__datadog_test_1));`)
         )
       })
+
+      it('does modify "hello".concat(...a, ...(b ? [c] : []))', () => {
+        const builder = fn().args('world', true, 'bye')
+        const js = builder.build('return "hello".concat(...a, ...(b ? [c] : []))')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+        return (__datadog_test_0 = "hello".concat, __datadog_test_1 = [\n...a\n], __datadog_test_2 = \
+[\n...(b ? [\nc\n] : [])\n], _ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1, ...__datadog_test_2), \
+__datadog_test_0, "hello", ...__datadog_test_1, ...__datadog_test_2));`)
+        )
+      })
     })
   })
 

--- a/test/string_method.spec.js
+++ b/test/string_method.spec.js
@@ -246,6 +246,18 @@ __datadog_test_0, [\n"world",\nnull\n]), __datadog_test_1, __datadog_test_0, "wo
       )
     })
 
+    it('does modify String.prototype.concat apply if this is null and there is a no literal arg', () => {
+      const js = 'String.prototype.concat.apply(null, ["world", a]);'
+      rewriteAndExpect(
+        js,
+        `{
+  let __datadog_test_0, __datadog_test_1;
+(__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(__datadog_test_0.apply(\
+null, [\n"world",\n__datadog_test_1\n]), __datadog_test_0, null, "world", __datadog_test_1));
+      }`
+      )
+    })
+
     it('does modify String.prototype.concat apply if an argument is not a literal', () => {
       const js = 'String.prototype.concat.apply("hello", ["world", a]);'
       rewriteAndExpect(
@@ -349,6 +361,18 @@ __datadog_test_1.call(__datadog_test_0, "world", ...__datadog_test_2), __datadog
         return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.concat(\
 __datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0\
 , ...__datadog_test_2));`)
+        )
+      })
+
+      it('does modify "hello".concat(...a)', () => {
+        const builder = fn().args('world')
+        const js = builder.build('return "hello".concat(...a)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1;
+        return (__datadog_test_0 = "hello".concat, __datadog_test_1 = a, _ddiast.concat(\
+__datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello"\
+, ...__datadog_test_1));`)
         )
       })
     })
@@ -467,7 +491,7 @@ __datadog_test_1.call(__datadog_test_0${argsWithComma}), __datadog_test_1, __dat
           )
         })
 
-        const formatArgs = function (args) {
+        const formatArgs = (args) => {
           if (!args) return ''
           return '\n' + args.replace(',', ',\n') + '\n'
         }

--- a/test/string_method.spec.js
+++ b/test/string_method.spec.js
@@ -132,7 +132,7 @@ _ddiast.stringSubstring(__datadog_test_1.call(__datadog_test_0, 2), __datadog_te
         `{
   let __datadog_test_0, __datadog_test_1;
 (__datadog_test_0 = b, __datadog_test_1 = String.prototype.substring, _ddiast.stringSubstring(__datadog_test_1\
-.call(__datadog_test_0, 2), __datadog_test_1, __datadog_test_0, 2));\n}`
+.apply(__datadog_test_0, [\n2\n]), __datadog_test_1, __datadog_test_0, 2));\n}`
       )
     })
 
@@ -143,7 +143,7 @@ _ddiast.stringSubstring(__datadog_test_1.call(__datadog_test_0, 2), __datadog_te
         `{
   let __datadog_test_0, __datadog_test_1;
 (__datadog_test_0 = b, __datadog_test_1 = String.prototype.substring, _ddiast.stringSubstring(__datadog_test_1\
-.call(__datadog_test_0, 2), __datadog_test_1, __datadog_test_0, 2));
+.apply(__datadog_test_0, [\n2\n], 1), __datadog_test_1, __datadog_test_0, 2, 1));
       }`
       )
     })
@@ -240,8 +240,8 @@ __datadog_test_1, "world"));
         js,
         `{
   let __datadog_test_0, __datadog_test_1;
-(__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, _ddiast.concat(__datadog_test_1.call(\
-__datadog_test_0, "world", null), __datadog_test_1, __datadog_test_0, "world", null));
+(__datadog_test_0 = a, __datadog_test_1 = String.prototype.concat, _ddiast.concat(__datadog_test_1.apply(\
+__datadog_test_0, [\n"world",\nnull\n]), __datadog_test_1, __datadog_test_0, "world", null));
       }`
       )
     })
@@ -253,13 +253,36 @@ __datadog_test_0, "world", null), __datadog_test_1, __datadog_test_0, "world", n
         `{
   let __datadog_test_0, __datadog_test_1;
 (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, \
-_ddiast.concat(__datadog_test_0.call("hello", "world", __datadog_test_1), __datadog_test_0, \
+_ddiast.concat(__datadog_test_0.apply("hello", [\n"world",\n__datadog_test_1\n]), __datadog_test_0, \
 "hello", "world", __datadog_test_1));
       }`
       )
     })
 
     describe('spread arguments', () => {
+      it('does modify String.prototype.concat.call(...a)', () => {
+        const builder = fn().args(['heLLo', ' ', 'world'])
+        const js = builder.build('return String.prototype.concat.call(...a)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1;
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+__datadog_test_0.call(...__datadog_test_1), __datadog_test_0, ...__datadog_test_1));`)
+        )
+      })
+
+      it('does modify String.prototype.concat.call(...a, ...b)', () => {
+        const builder = fn().args(['heLLo', ' ', 'world'], [' ', 'bye'])
+        const js = builder.build('return String.prototype.concat.call(...a, ...b)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, __datadog_test_2 = b, _ddiast.concat(\
+__datadog_test_0.call(...__datadog_test_1, ...__datadog_test_2), __datadog_test_0, ...__datadog_test_1, \
+...__datadog_test_2));`)
+        )
+      })
+
       it('does modify String.prototype.concat.call("hello", ...a)', () => {
         const builder = fn().args([' ', 'heLLo', ' ', 'world'])
         const js = builder.build('return String.prototype.concat.call("hello", ...a)')
@@ -283,6 +306,28 @@ _ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1, ...__datadog_
         )
       })
 
+      it('does modify String.prototype.concat.apply("hello", ...a)', () => {
+        const builder = fn().args([['heLLo'], ' ', 'world'])
+        const js = builder.build('return String.prototype.concat.apply("hello", ...a)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1;
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+__datadog_test_0.apply("hello", ...__datadog_test_1), __datadog_test_0, "hello", ...__datadog_test_1));`)
+        )
+      })
+
+      it('does modify String.prototype.concat.apply(...a)', () => {
+        const builder = fn().args(['heLLo', [' ', 'world']])
+        const js = builder.build('return String.prototype.concat.apply(...a)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1;
+        return (__datadog_test_0 = String.prototype.concat, __datadog_test_1 = a, _ddiast.concat(\
+__datadog_test_0.apply(...__datadog_test_1), __datadog_test_0, ...__datadog_test_1));`)
+        )
+      })
+
       it('does modify a.concat("world", ...b)', () => {
         const builder = fn().args('hello', [' ', 'bye', ' ', 'world'])
         const js = builder.build('return a.concat("world", ...b)')
@@ -292,6 +337,18 @@ _ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1, ...__datadog_
         return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.concat(\
 __datadog_test_1.call(__datadog_test_0, "world", ...__datadog_test_2), __datadog_test_1, __datadog_test_0\
 , "world", ...__datadog_test_2));`)
+        )
+      })
+
+      it('does modify a.concat(...b)', () => {
+        const builder = fn().args('hello', [' ', 'bye', ' ', 'world'])
+        const js = builder.build('return a.concat(...b)')
+        rewriteAndExpectAndExpectEval(
+          js,
+          builder.build(`let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+        return (__datadog_test_0 = a, __datadog_test_1 = __datadog_test_0.concat, __datadog_test_2 = b, _ddiast.concat(\
+__datadog_test_1.call(__datadog_test_0, ...__datadog_test_2), __datadog_test_1, __datadog_test_0\
+, ...__datadog_test_2));`)
         )
       })
     })
@@ -410,6 +467,11 @@ __datadog_test_1.call(__datadog_test_0${argsWithComma}), __datadog_test_1, __dat
           )
         })
 
+        const formatArgs = function (args) {
+          if (!args) return ''
+          return '\n' + args.replace(',', ',\n') + '\n'
+        }
+
         it(`does modify String.prototype.${value}.apply with variable argument`, () => {
           const builder = fn().args('heLLo')
           const js = builder.build(`String.prototype.${method}.apply(a, [${args}]);`)
@@ -417,7 +479,8 @@ __datadog_test_1.call(__datadog_test_0${argsWithComma}), __datadog_test_1, __dat
             js,
             builder.build(`let __datadog_test_0, __datadog_test_1;
     (__datadog_test_0 = a, __datadog_test_1 = String.prototype.${method}, _ddiast.${method}(\
-__datadog_test_1.call(__datadog_test_0${argsWithComma}), __datadog_test_1, __datadog_test_0${argsWithComma}));`)
+__datadog_test_1.apply(__datadog_test_0, [${formatArgs(args)}]), __datadog_test_1, \
+__datadog_test_0${argsWithComma}));`)
           )
         })
       })


### PR DESCRIPTION
### What does this PR do?

- Add support to spread operator in expressions like `.call`, `.apply` or direct invocations like `.concat(...a)`
To avoid executing a possible getter twice, an array is used to spread the argument first, the array is assigned to a temporary variable that is reused in the rewritten expression.

```javascript
// original
"hello".concat(...a)

// rewritten
__datadog_test_0 = "hello".concat, 
__datadog_test_1 = [...a],
_ddiast.concat(__datadog_test_0.call("hello", ...__datadog_test_1), __datadog_test_0, "hello", ...__datadog_test_1))


```

- Changes the way `.apply` calls were rewritten. Until now, they were transformed into `.call` expressions (when possible) but with the spread operator support they are kept as `.apply` expressions.


### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
