### PR TITLE
Rewrite template literals as template literals

### DIFF
--- a/scripts/crawler.js
+++ b/scripts/crawler.js
@@ -20,23 +20,24 @@ const V8_NATIVE_CALL_REPLACEMENT_REGEX = /__v8_native_remainder(\w+\(\S*?|\s*\))
 const V8_NATIVE_CALL_FLAGS_COMMENT_REGEX = /\/\/\s*Flags:.*(--allow-natives)+/gm
 
 const CSI_METHODS = [
+  { src: 'eval', allowedWithoutCallee: true },
+  { src: 'plusOperator', operator: true },
+  { src: 'tplOperator', operator: true },
   { src: 'concat' },
   { src: 'join' },
-  { src: 'plusOperator', operator: true },
   { src: 'replace' },
   { src: 'replaceAll' },
-  { src: 'substring' },
   { src: 'slice' },
-  { src: 'trim' },
-  { src: 'trimEnd' },
-  { src: 'trimLeft' },
-  { src: 'trimRight' },
-  { src: 'trimStart' },
+  { src: 'substring' },
   { src: 'toLocaleLowerCase' },
   { src: 'toLocaleUpperCase' },
   { src: 'toLowerCase' },
   { src: 'toUpperCase' },
-  { src: 'eval', allowedWithoutCallee: true }
+  { src: 'trim' },
+  { src: 'trimEnd' },
+  { src: 'trimLeft' },
+  { src: 'trimRight' },
+  { src: 'trimStart' }
 ]
 
 const GLOBAL_METHODS_TEMPLATE = `;(function(globals){

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -73,6 +73,7 @@ fn rewrite_js_with_config(code: String, config: &Config) -> Result<RewrittenOutp
 fn get_default_csi_methods() -> CsiMethods {
     let mut methods = vec![
         csi_op_from_str("plusOperator", None),
+        csi_op_from_str("tplOperator", None),
         csi_from_str("substring", Some("stringSubstring")),
         csi_from_str("trim", Some("stringTrim")),
         csi_from_str("trimStart", Some("stringTrim")),

--- a/src/tests/template_literal_test.rs
+++ b/src/tests/template_literal_test.rs
@@ -15,7 +15,7 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("const a = _ddiast.plusOperator(b + \"Hello\", b, \"Hello\");");
+            .contains("const a = (__datadog_test_0 = b, _ddiast.tplOperator(`${__datadog_test_0}Hello`, __datadog_test_0));");
         Ok(())
     }
 
@@ -25,7 +25,7 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("const a = _ddiast.plusOperator(\"Hello\" + b, \"Hello\", b);");
+            .contains("const a = (__datadog_test_0 = b, _ddiast.tplOperator(`Hello${__datadog_test_0}`, __datadog_test_0));");
         Ok(())
     }
 
@@ -35,8 +35,8 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("let __datadog_test_0, __datadog_test_1;
-    const a = (__datadog_test_1 = (__datadog_test_0 = b(), _ddiast.plusOperator(__datadog_test_0 + \"llo\", __datadog_test_0, \"llo\")), _ddiast.plusOperator(\"He\" + __datadog_test_1, \"He\", __datadog_test_1));");
+            .contains("let __datadog_test_0;
+    const a = (__datadog_test_0 = b(), _ddiast.tplOperator(`He${__datadog_test_0}llo`, __datadog_test_0));");
         Ok(())
     }
 
@@ -46,8 +46,8 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("let __datadog_test_0, __datadog_test_1;
-    const a = (__datadog_test_1 = (__datadog_test_0 = _ddiast.plusOperator(b + c, b, c), _ddiast.plusOperator(__datadog_test_0 + \"llo\", __datadog_test_0, \"llo\")), _ddiast.plusOperator(\"He\" + __datadog_test_1, \"He\", __datadog_test_1));");
+            .contains("let __datadog_test_0;
+    const a = (__datadog_test_0 = _ddiast.plusOperator(b + c, b, c), _ddiast.tplOperator(`He${__datadog_test_0}llo`, __datadog_test_0));");
         Ok(())
     }
 
@@ -57,8 +57,8 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("let __datadog_test_0, __datadog_test_1, __datadog_test_2, __datadog_test_3;
-    const a = (__datadog_test_3 = (__datadog_test_2 = (__datadog_test_0 = b, __datadog_test_1 = c(), _ddiast.plusOperator(__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.plusOperator(__datadog_test_2 + \"llo\", __datadog_test_2, \"llo\")), _ddiast.plusOperator(\"He\" + __datadog_test_3, \"He\", __datadog_test_3));");
+            .contains("let __datadog_test_0, __datadog_test_1, __datadog_test_2;
+    const a = (__datadog_test_2 = (__datadog_test_0 = b, __datadog_test_1 = c(), _ddiast.plusOperator(__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.tplOperator(`He${__datadog_test_2}llo`, __datadog_test_2));");
         Ok(())
     }
 
@@ -68,7 +68,7 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("const a = (__datadog_test_3 = (__datadog_test_1 = typeof b, __datadog_test_2 = (__datadog_test_0 = _ddiast.plusOperator(a + \"ld\", a, \"ld\"), _ddiast.plusOperator(\"llo wor\" + __datadog_test_0, \"llo wor\", __datadog_test_0)), _ddiast.plusOperator(__datadog_test_1 + __datadog_test_2, __datadog_test_1, __datadog_test_2)), _ddiast.plusOperator(\"He\" + __datadog_test_3, \"He\", __datadog_test_3));");
+            .contains("const a = (__datadog_test_0 = typeof b, __datadog_test_1 = a, _ddiast.tplOperator(`He${__datadog_test_0}llo wor${__datadog_test_1}ld`, __datadog_test_0, __datadog_test_1));");
         Ok(())
     }
 
@@ -78,7 +78,7 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("let __datadog_test_0;\n    const a = (__datadog_test_0 = b.x, _ddiast.plusOperator(\"Hello world \" + __datadog_test_0, \"Hello world \", __datadog_test_0));");
+            .contains("let __datadog_test_0;\n    const a = (__datadog_test_0 = b.x, _ddiast.tplOperator(`Hello world ${__datadog_test_0}`, __datadog_test_0));");
         Ok(())
     }
 
@@ -92,8 +92,8 @@ mod tests {
         let js_file = "test.js".to_string();
         let rewritten = rewrite_js(original_code, js_file).map_err(|e| e.to_string())?;
         assert_that(&rewritten.code)
-            .contains("function* foo() {\n    let __datadog_test_0, __datadog_test_1;
-    var f = (__datadog_test_1 = (__datadog_test_0 = yield 'yielded', _ddiast.plusOperator(__datadog_test_0 + \"bar\", __datadog_test_0, \"bar\")), _ddiast.plusOperator(\"foo\" + __datadog_test_1, \"foo\", __datadog_test_1));");
+            .contains("function* foo() {\n    let __datadog_test_0;
+    var f = (__datadog_test_0 = yield 'yielded', _ddiast.tplOperator(`foo${__datadog_test_0}bar`, __datadog_test_0));");
         Ok(())
     }
 }

--- a/src/transform/template_transform.rs
+++ b/src/transform/template_transform.rs
@@ -2,79 +2,58 @@
 * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 **/
-use swc::atoms::JsWord;
-use swc_common::DUMMY_SP;
+use swc_common::Spanned;
 use swc_ecma_ast::*;
+
+use crate::visitor::{
+    csi_methods::CsiMethods,
+    ident_provider::{IdentKind, IdentProvider},
+    visitor_util::get_dd_paren_expr,
+};
+
+use super::{
+    operand_handler::{DefaultOperandHandler, ExpandArrays, IdentMode, OperandHandler},
+    transform_status::TransformResult,
+};
 
 pub struct TemplateTransform {}
 
 impl TemplateTransform {
-    pub fn get_binary_from_tpl(tpl: &Tpl) -> Expr {
-        let arguments = get_reversed_arguments(tpl);
-        // with `${expression}` first quasi is filtered
-        let left: Expr = if arguments.len() == 1 {
-            Expr::Lit(Lit::Str(Str {
-                span: tpl.span,
-                raw: None,
-                value: JsWord::from(""),
-            }))
-        } else {
-            arguments[1].clone()
-        };
+    pub fn to_dd_tpl_expr(
+        expr: &mut Expr,
+        csi_methods: &CsiMethods,
+        ident_provider: &mut dyn IdentProvider,
+    ) -> TransformResult<Expr> {
+        if let Expr::Tpl(tpl) = expr {
+            let mut assignations = Vec::new();
+            let mut arguments = Vec::new();
 
-        let mut binary_expr = BinExpr {
-            span: DUMMY_SP,
-            op: BinaryOp::Add,
-            left: Box::new(left),
-            right: Box::new(arguments[0].clone()),
-        };
+            tpl.exprs.iter_mut().for_each(|tpl_expr| {
+                let span = tpl_expr.span();
 
-        arguments.iter().skip(2).for_each(|arg| {
-            binary_expr = BinExpr {
-                span: DUMMY_SP,
-                op: BinaryOp::Add,
-                left: Box::new(arg.clone()),
-                right: Box::new(Expr::Bin(binary_expr.clone())),
-            }
-        });
-        Expr::Bin(binary_expr)
-    }
-}
+                DefaultOperandHandler::replace_expressions_in_expr(
+                    tpl_expr,
+                    IdentMode::Replace,
+                    &mut assignations,
+                    &mut arguments,
+                    &span,
+                    ident_provider,
+                    IdentKind::Expr,
+                    ExpandArrays::No,
+                )
+            });
 
-fn get_reversed_arguments(tpl: &Tpl) -> Vec<Expr> {
-    let mut arguments = Vec::new();
-    let mut index = 0;
-    let empty_quasi = JsWord::from("");
-    let mut last_skipped = false;
-    for quasi in &tpl.quasis {
-        let value = quasi.cooked.clone();
-        if value.is_none() || value.unwrap() == empty_quasi {
-            if !quasi.tail {
-                let expr = &*tpl.exprs[index];
-                arguments.push(expr.clone());
-                index += 1;
-                last_skipped = true;
-            }
-            if !quasi.tail || !last_skipped {
-                continue;
-            }
-        }
-        last_skipped = false;
+            let dd_expr = get_dd_paren_expr(
+                expr,
+                &arguments,
+                &mut assignations,
+                &csi_methods.get_dd_tpl_operator_name(),
+                &expr.span(),
+            );
 
-        let str = Expr::Lit(Lit::Str(Str {
-            span: quasi.span,
-            raw: None,
-            value: quasi.cooked.clone().unwrap_or_else(|| empty_quasi.clone()),
-        }));
-        arguments.push(str);
-
-        if !quasi.tail {
-            let expr = &*tpl.exprs[index];
-            arguments.push(expr.clone());
+            return TransformResult::modified(dd_expr);
         }
 
-        index += 1;
+        TransformResult::not_modified()
     }
-    arguments.reverse();
-    arguments
 }

--- a/src/visitor/csi_methods.rs
+++ b/src/visitor/csi_methods.rs
@@ -2,7 +2,7 @@
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
  * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
  **/
-use super::visitor_util::DD_PLUS_OPERATOR;
+use super::visitor_util::{DD_PLUS_OPERATOR, DD_TEMPLATE_LITERAL_OPERATOR};
 
 #[derive(Clone, Debug)]
 pub struct CsiMethod {
@@ -33,6 +33,7 @@ impl CsiMethod {
 pub struct CsiMethods {
     pub methods: Vec<CsiMethod>,
     pub plus_operator: Option<CsiMethod>,
+    pub tpl_operator: Option<CsiMethod>,
     pub method_with_literal_callers: Vec<&'static str>,
 }
 
@@ -42,9 +43,14 @@ impl CsiMethods {
             .iter()
             .find(|csi_method| csi_method.operator && csi_method.src == DD_PLUS_OPERATOR);
 
+        let tpl_operator = csi_methods.iter().find(|csi_method| {
+            csi_method.operator && csi_method.src == DD_TEMPLATE_LITERAL_OPERATOR
+        });
+
         CsiMethods {
             methods: csi_methods.to_vec(),
             plus_operator: plus_operator.cloned(),
+            tpl_operator: tpl_operator.cloned(),
             method_with_literal_callers: vec![
                 "concat",
                 "replace",
@@ -60,6 +66,7 @@ impl CsiMethods {
         CsiMethods {
             methods: vec![],
             plus_operator: None,
+            tpl_operator: None,
             method_with_literal_callers: vec![],
         }
     }
@@ -74,10 +81,21 @@ impl CsiMethods {
         self.plus_operator.is_some()
     }
 
+    pub fn tpl_operator_is_enabled(&self) -> bool {
+        self.tpl_operator.is_some()
+    }
+
     pub fn get_dd_plus_operator_name(&self) -> String {
         match &self.plus_operator {
             Some(csi_method) => csi_method.dst.clone(),
             _ => DD_PLUS_OPERATOR.to_string(),
+        }
+    }
+
+    pub fn get_dd_tpl_operator_name(&self) -> String {
+        match &self.tpl_operator {
+            Some(csi_method) => csi_method.dst.clone(),
+            _ => DD_TEMPLATE_LITERAL_OPERATOR.to_string(),
         }
     }
 

--- a/src/visitor/visitor_util.rs
+++ b/src/visitor/visitor_util.rs
@@ -9,6 +9,7 @@ use swc_ecma_ast::*;
 const DATADOG_VAR_PREFIX: &str = "__datadog";
 const DD_GLOBAL_NAMESPACE: &str = "_ddiast";
 pub const DD_PLUS_OPERATOR: &str = "plusOperator";
+pub const DD_TEMPLATE_LITERAL_OPERATOR: &str = "tplOperator";
 
 pub fn get_dd_local_variable_name(n: usize, prefix: &String) -> String {
     format!("{}{}", get_dd_local_variable_prefix(prefix), n)

--- a/test/resources/tmpl-literal.js
+++ b/test/resources/tmpl-literal.js
@@ -1,3 +1,5 @@
 module.exports = {
   RAW_AND_NEWLINE: String.raw`Hi\nworld`,
+  RAW_AND_NEWLINE2: String.raw`Hi
+    world`,
 }

--- a/test/resources/tmpl-literal.js
+++ b/test/resources/tmpl-literal.js
@@ -1,0 +1,3 @@
+module.exports = {
+  RAW_AND_NEWLINE: String.raw`Hi\nworld`,
+}

--- a/test/template_literal.spec.js
+++ b/test/template_literal.spec.js
@@ -4,7 +4,7 @@
  **/
 /* eslint-disable no-template-curly-in-string */
 /* eslint-disable no-multi-str */
-const { rewriteAst, rewriteAndExpectNoTransformation, rewriteAndExpect } = require('./util')
+const { rewriteAst, rewriteAndExpectNoTransformation, rewriteAndExpect, csiMethods } = require('./util')
 const { readFileSync } = require('fs')
 const path = require('path')
 
@@ -18,6 +18,13 @@ describe('template literal', () => {
     it('literal', () => {
       const js = 'const result = `Hello${" "}World!`;'
       rewriteAndExpectNoTransformation(js)
+    })
+
+    it('not enabled tplOperator', () => {
+      const js = 'const result = `Hello${a}World!`;'
+      rewriteAndExpectNoTransformation(js, {
+        csiMethods: csiMethods.filter((m) => m.src !== 'tplOperator')
+      })
     })
 
     it('middle', () => {

--- a/test/template_literal.spec.js
+++ b/test/template_literal.spec.js
@@ -23,14 +23,18 @@ describe('template literal', () => {
       rewriteAndExpect(
         js,
         '{\nlet __datadog_test_0;\n\
-          const result = (__datadog_test_0 = _ddiast.plusOperator(a + "World!", a, "World!"), _ddiast.plusOperator(\
-"Hello" + __datadog_test_0, "Hello", __datadog_test_0));\n}'
+          const result = (__datadog_test_0 = a, _ddiast.tplOperator(`Hello${__datadog_test_0}World!`, \
+__datadog_test_0));\n}'
       )
     })
 
     it('start', () => {
       const js = 'const result = `${a}Hello World!`;'
-      rewriteAndExpect(js, '{\nconst result = _ddiast.plusOperator(a + "Hello World!", a, "Hello World!");\n}')
+      rewriteAndExpect(
+        js,
+        '{\nlet __datadog_test_0;\n\
+const result = (__datadog_test_0 = a, _ddiast.tplOperator(`${__datadog_test_0}Hello World!`, __datadog_test_0));\n}'
+      )
     })
 
     it('multiline string', () => {
@@ -45,13 +49,15 @@ describe('template literal', () => {
 </html>\`);
   });`
       const expected = `{\nrouter.get('/xss', function(req, res) {
-    let __datadog_test_0, __datadog_test_1;
+    let __datadog_test_0;
     res.header('content-type', 'text/html');
-    res.send((__datadog_test_1 = (__datadog_test_0 = req.query.param, _ddiast.plusOperator(__datadog_test_0 + "</p>\
-\\n    </body>\\n</body>\\n</html>", __datadog_test_0, "</p>\\n    </body>\\n</body>\\n</html>")), \
-_ddiast.plusOperator('<html lang="en">\\n    <body>\\n        <h1>XSS vulnerability</h1>\\n        \
-<p>Received param: ' + __datadog_test_1, '<html lang="en">\\n    <body>\\n        <h1>XSS vulnerability</h1>\
-\\n        <p>Received param: ', __datadog_test_1)));
+    res.send((__datadog_test_0 = req.query.param, _ddiast.tplOperator(\`<html lang="en">
+      <body>
+      <h1>XSS vulnerability</h1>
+      <p>Received param: \${__datadog_test_0}</p>
+      </body>
+      </body>
+      </html>\`, __datadog_test_0)));
 });\n}`
       rewriteAndExpect(js, expected)
     })
@@ -61,14 +67,18 @@ _ddiast.plusOperator('<html lang="en">\\n    <body>\\n        <h1>XSS vulnerabil
       rewriteAndExpect(
         js,
         '{\nlet __datadog_test_0, __datadog_test_1;\n\
-const result = (__datadog_test_0 = a, __datadog_test_1 = _ddiast.plusOperator(b + "", b, ""), \
-_ddiast.plusOperator(__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1));\n}'
+const result = (__datadog_test_0 = a, __datadog_test_1 = b, _ddiast.tplOperator(\
+`${__datadog_test_0}${__datadog_test_1}`, __datadog_test_0, __datadog_test_1));\n}'
       )
     })
 
     it('end', () => {
       const js = 'const result = `Hello World!${a}`;'
-      rewriteAndExpect(js, '{\nconst result = _ddiast.plusOperator("Hello World!" + a, "Hello World!", a);\n}')
+      rewriteAndExpect(
+        js,
+        '{\nlet __datadog_test_0;\n\
+const result = (__datadog_test_0 = a, _ddiast.tplOperator(`Hello World!${__datadog_test_0}`, __datadog_test_0));\n}'
+      )
     })
 
     it('with binary operations', () => {
@@ -76,8 +86,8 @@ _ddiast.plusOperator(__datadog_test_0 + __datadog_test_1, __datadog_test_0, __da
       rewriteAndExpect(
         js,
         '{\nlet __datadog_test_0;\n\
-        const result = (__datadog_test_0 = _ddiast.plusOperator(a + b, a, b), _ddiast.plusOperator("Hello World!" \
-+ __datadog_test_0, "Hello World!", __datadog_test_0));\n}'
+        const result = (__datadog_test_0 = _ddiast.plusOperator(a + b, a, b), _ddiast.tplOperator(\
+`Hello World!${__datadog_test_0}`, __datadog_test_0));\n}'
       )
     })
 
@@ -85,8 +95,8 @@ _ddiast.plusOperator(__datadog_test_0 + __datadog_test_1, __datadog_test_0, __da
       const js = 'const result = `Hello World!${a()}`;'
       rewriteAndExpect(
         js,
-        '{\nlet __datadog_test_0;\nconst result = (__datadog_test_0 = a(), _ddiast.plusOperator("Hello World!" \
-+ __datadog_test_0, "Hello World!", __datadog_test_0));\n}'
+        '{\nlet __datadog_test_0;\nconst result = (__datadog_test_0 = a(), _ddiast.tplOperator(\
+`Hello World!${__datadog_test_0}`, __datadog_test_0));\n}'
       )
     })
 
@@ -96,8 +106,8 @@ _ddiast.plusOperator(__datadog_test_0 + __datadog_test_1, __datadog_test_0, __da
         js,
         '{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2;\n\
         const result = (__datadog_test_2 = (__datadog_test_0 = a, __datadog_test_1 = b(), _ddiast.plusOperator(\
-__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.plusOperator("Hello World!" \
-+ __datadog_test_2, "Hello World!", __datadog_test_2));\n}'
+__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.tplOperator(\
+`Hello World!${__datadog_test_2}`, __datadog_test_2));\n}'
       )
     })
 
@@ -107,8 +117,8 @@ __datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddia
         js,
         '{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2;\n\
         const result = (__datadog_test_2 = (__datadog_test_0 = a, __datadog_test_1 = b.x, _ddiast.plusOperator(\
-__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.plusOperator("Hello World!" \
-+ __datadog_test_2, "Hello World!", __datadog_test_2));\n}'
+__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.tplOperator(\
+`Hello World!${__datadog_test_2}`, __datadog_test_2));\n}'
       )
     })
 
@@ -118,30 +128,38 @@ __datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddia
         js,
         '{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2;\n\
         const result = (__datadog_test_2 = (__datadog_test_0 = a, __datadog_test_1 = b.x.y.z, _ddiast.plusOperator(\
-__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.plusOperator("Hello World!" + \
-__datadog_test_2, "Hello World!", __datadog_test_2));\n}'
+__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.tplOperator(\
+`Hello World!${__datadog_test_2}`, __datadog_test_2));\n}'
       )
     })
 
     it('inside if test', () => {
       const js = 'const c = a === `Hello${b}` ? "world" : "moon";'
-      rewriteAndExpect(js, '{\nconst c = a === _ddiast.plusOperator("Hello" + b, "Hello", b) ? "world" : "moon";\n}')
+      rewriteAndExpect(
+        js,
+        '{\nlet __datadog_test_0;\n\
+const c = a === (__datadog_test_0 = b, _ddiast.tplOperator(`Hello${__datadog_test_0}`, __datadog_test_0)) ? "world" : \
+"moon";\n}'
+      )
     })
 
     it('inside if cons', () => {
       const js = 'const c = a === "hello" ? `World ${b}` : "Moon";'
-      rewriteAndExpect(js, '{\nconst c = a === "hello" ? _ddiast.plusOperator("World " + b, "World ", b) : "Moon";\n}')
+      rewriteAndExpect(
+        js,
+        '{\nlet __datadog_test_0;\n\
+const c = a === "hello" ? (__datadog_test_0 = b, _ddiast.tplOperator(`World ${__datadog_test_0}`, __datadog_test_0)) \
+: "Moon";\n}'
+      )
     })
 
     it('typeof among variables is replaced by a variable', () => {
       const js = 'const a = `He${typeof b}llo wor${a}ld`'
       rewriteAndExpect(
         js,
-        '{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2, __datadog_test_3;\n\
-        const a = (__datadog_test_3 = (__datadog_test_1 = typeof b, __datadog_test_2 = (__datadog_test_0 \
-= _ddiast.plusOperator(a + "ld", a, "ld"), _ddiast.plusOperator("llo wor" + __datadog_test_0, "llo wor", \
-__datadog_test_0)), _ddiast.plusOperator(__datadog_test_1 + __datadog_test_2, __datadog_test_1, __datadog_test_2))\
-, _ddiast.plusOperator("He" + __datadog_test_3, "He", __datadog_test_3));\n}'
+        '{\nlet __datadog_test_0, __datadog_test_1;\n\
+const a = (__datadog_test_0 = typeof b, __datadog_test_1 = a, _ddiast.tplOperator(`He${__datadog_test_0}llo \
+wor${__datadog_test_1}ld`, __datadog_test_0, __datadog_test_1));\n}'
       )
     })
 
@@ -159,15 +177,11 @@ __datadog_test_0)), _ddiast.plusOperator(__datadog_test_1 + __datadog_test_2, __
       const js = "const a = `Hello ${c} ${'how are u ' + `${'bye ' + d}`} world`;"
       rewriteAndExpect(
         js,
-        '{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2, __datadog_test_3, __datadog_test_4\
-, __datadog_test_5, __datadog_test_6;\n\
-const a = (__datadog_test_6 = (__datadog_test_4 = c, __datadog_test_5 = (__datadog_test_3 = (__datadog_test_2 = (\
-__datadog_test_1 = (__datadog_test_0 = _ddiast.plusOperator(\'bye \' + d, \'bye \', d), _ddiast.plusOperator(\
-__datadog_test_0 + "", __datadog_test_0, "")), _ddiast.plusOperator(\'how are u \' + __datadog_test_1, \'how are u \', \
-__datadog_test_1)), _ddiast.plusOperator(__datadog_test_2 + " world", __datadog_test_2, " world")), \
-_ddiast.plusOperator(" " + __datadog_test_3, " ", __datadog_test_3)), _ddiast.plusOperator(__datadog_test_4 + \
-__datadog_test_5, __datadog_test_4, __datadog_test_5)), _ddiast.plusOperator("Hello " + __datadog_test_6, "Hello "\
-, __datadog_test_6));\n}'
+        "{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2, __datadog_test_3;\n\
+const a = (__datadog_test_2 = c, __datadog_test_3 = (__datadog_test_1 = (__datadog_test_0 = _ddiast.plusOperator(\
+'bye ' + d, 'bye ', d), _ddiast.tplOperator(`${__datadog_test_0}`, __datadog_test_0)), _ddiast.plusOperator(\
+'how are u ' + __datadog_test_1, 'how are u ', __datadog_test_1)), _ddiast.tplOperator(\
+`Hello ${__datadog_test_2} ${__datadog_test_3} world`, __datadog_test_2, __datadog_test_3));\n}"
       )
     })
 
@@ -175,8 +189,8 @@ __datadog_test_5, __datadog_test_4, __datadog_test_5)), _ddiast.plusOperator("He
       const js = 'const a = `Hello ${c++}`;'
       rewriteAndExpect(
         js,
-        '{\nlet __datadog_test_0;\nconst a = (__datadog_test_0 = c++, _ddiast.plusOperator("Hello " + __datadog_test_0\
-, "Hello ", __datadog_test_0));\n}'
+        '{\nlet __datadog_test_0;\nconst a = (__datadog_test_0 = c++, _ddiast.tplOperator(`Hello ${__datadog_test_0}`, \
+__datadog_test_0));\n}'
       )
     })
 
@@ -184,8 +198,8 @@ __datadog_test_5, __datadog_test_4, __datadog_test_5)), _ddiast.plusOperator("He
       const js = 'const a = `Hello ${--c}`;'
       rewriteAndExpect(
         js,
-        '{\nlet __datadog_test_0;\nconst a = (__datadog_test_0 = --c, _ddiast.plusOperator("Hello " + __datadog_test_0\
-, "Hello ", __datadog_test_0));\n}'
+        '{\nlet __datadog_test_0;\nconst a = (__datadog_test_0 = --c, _ddiast.tplOperator(`Hello ${__datadog_test_0}`, \
+__datadog_test_0));\n}'
       )
     })
 
@@ -193,8 +207,8 @@ __datadog_test_5, __datadog_test_4, __datadog_test_5)), _ddiast.plusOperator("He
       const js = 'const a = `Hello ${await b()}`;'
       rewriteAndExpect(
         js,
-        '{\nlet __datadog_test_0;\nconst a = (__datadog_test_0 = await b(), _ddiast.plusOperator("Hello " + \
-__datadog_test_0, "Hello ", __datadog_test_0));\n}'
+        '{\nlet __datadog_test_0;\n\
+const a = (__datadog_test_0 = await b(), _ddiast.tplOperator(`Hello ${__datadog_test_0}`, __datadog_test_0));\n}'
       )
     })
 
@@ -204,8 +218,8 @@ __datadog_test_0, "Hello ", __datadog_test_0));\n}'
         js,
         '{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2;\n\
           const a = (__datadog_test_2 = (__datadog_test_0 = b, __datadog_test_1 = await c(), _ddiast.plusOperator(\
-__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.plusOperator("Hello " + \
-__datadog_test_2, "Hello ", __datadog_test_2));\n}'
+__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.tplOperator(\
+`Hello ${__datadog_test_2}`, __datadog_test_2));\n}'
       )
     })
 
@@ -214,8 +228,8 @@ __datadog_test_2, "Hello ", __datadog_test_2));\n}'
       rewriteAndExpect(
         js,
         '{\nlet __datadog_test_0;\n\
-          const a = (__datadog_test_0 = _ddiast.plusOperator(b + c, b, c) ? d : e, _ddiast.plusOperator("Hello " \
-+ __datadog_test_0, "Hello ", __datadog_test_0));\n}'
+          const a = (__datadog_test_0 = _ddiast.plusOperator(b + c, b, c) ? d : e, _ddiast.tplOperator(\
+`Hello ${__datadog_test_0}`, __datadog_test_0));\n}'
       )
     })
 
@@ -225,8 +239,8 @@ __datadog_test_2, "Hello ", __datadog_test_2));\n}'
         js,
         '{\nlet __datadog_test_0, __datadog_test_1, __datadog_test_2;\n\
         const a = (__datadog_test_2 = (__datadog_test_0 = a, __datadog_test_1 = new B(), _ddiast.plusOperator(\
-__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.plusOperator("Hello " + \
-__datadog_test_2, "Hello ", __datadog_test_2));\n}'
+__datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.tplOperator(\
+`Hello ${__datadog_test_2}`, __datadog_test_2));\n}'
       )
     })
   })
@@ -235,7 +249,8 @@ __datadog_test_2, "Hello ", __datadog_test_2));\n}'
     // Used in rewritten code
     // eslint-disable-next-line no-unused-vars
     const _ddiast = {
-      plusOperator: (res) => res
+      plusOperator: (res) => res,
+      tplOperator: (res) => res
     }
     function rewriteAndCompare (origFunc, args) {
       const expectedResult = origFunc(...args)

--- a/test/template_literal.spec.js
+++ b/test/template_literal.spec.js
@@ -246,7 +246,7 @@ __datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddia
       )
     })
 
-    it.only('with String.raw + tagged template + \\n', () => {
+    it('with String.raw + tagged template + \\n', () => {
       const js = readFileSync(path.join(__dirname, 'resources/tmpl-literal.js')).toString()
       const rewritten = rewriteAndExpectNoTransformation(js)
 
@@ -254,6 +254,17 @@ __datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddia
       const e1 = eval(js).RAW_AND_NEWLINE
       // eslint-disable-next-line no-eval
       const e2 = eval(rewritten).RAW_AND_NEWLINE
+      expect(e1).to.be.equal(e2)
+    })
+
+    it('with String.raw + tagged template + new line', () => {
+      const js = readFileSync(path.join(__dirname, 'resources/tmpl-literal.js')).toString()
+      const rewritten = rewriteAndExpectNoTransformation(js)
+
+      // eslint-disable-next-line no-eval
+      const e1 = eval(js).RAW_AND_NEWLINE2
+      // eslint-disable-next-line no-eval
+      const e2 = eval(rewritten).RAW_AND_NEWLINE2
       expect(e1).to.be.equal(e2)
     })
   })

--- a/test/template_literal.spec.js
+++ b/test/template_literal.spec.js
@@ -5,6 +5,8 @@
 /* eslint-disable no-template-curly-in-string */
 /* eslint-disable no-multi-str */
 const { rewriteAst, rewriteAndExpectNoTransformation, rewriteAndExpect } = require('./util')
+const { readFileSync } = require('fs')
+const path = require('path')
 
 describe('template literal', () => {
   describe('rewriting tests', () => {
@@ -242,6 +244,17 @@ __datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddia
 __datadog_test_0 + __datadog_test_1, __datadog_test_0, __datadog_test_1)), _ddiast.tplOperator(\
 `Hello ${__datadog_test_2}`, __datadog_test_2));\n}'
       )
+    })
+
+    it.only('with String.raw + tagged template + \\n', () => {
+      const js = readFileSync(path.join(__dirname, 'resources/tmpl-literal.js')).toString()
+      const rewritten = rewriteAndExpectNoTransformation(js)
+
+      // eslint-disable-next-line no-eval
+      const e1 = eval(js).RAW_AND_NEWLINE
+      // eslint-disable-next-line no-eval
+      const e2 = eval(rewritten).RAW_AND_NEWLINE
+      expect(e1).to.be.equal(e2)
     })
   })
 

--- a/test/tracer_logger.spec.js
+++ b/test/tracer_logger.spec.js
@@ -40,8 +40,8 @@ describe('logger', () => {
     expect(logger.debug.secondCall.args).to.deep.eq([
       'Rewriting js file: test.js with config: \
 Config { chain_source_map: false, print_comments: false, local_var_prefix: "logger-test", csi_methods: \
-CsiMethods { methods: [], plus_operator: None, method_with_literal_callers: [] }, verbosity: Information, \
-literals: true }'
+CsiMethods { methods: [], plus_operator: None, tpl_operator: None, method_with_literal_callers: [] }, \
+verbosity: Information, literals: true }'
     ])
   })
 
@@ -57,8 +57,8 @@ literals: true }'
     expect(debug.secondCall.args).to.deep.eq([
       'Rewriting js file: test.js with config: \
 Config { chain_source_map: false, print_comments: false, local_var_prefix: "logger-test", csi_methods: \
-CsiMethods { methods: [], plus_operator: None, method_with_literal_callers: [] }, verbosity: Information, \
-literals: true }'
+CsiMethods { methods: [], plus_operator: None, tpl_operator: None, method_with_literal_callers: [] }, \
+verbosity: Information, literals: true }'
     ])
   })
 

--- a/test/util.js
+++ b/test/util.js
@@ -61,13 +61,14 @@ const rewriteAst = (code, opts) => {
 const wrapBlock = (code) => `{${os.EOL}${code}${os.EOL}}`
 
 const rewriteAndExpectNoTransformation = (code, opts) => {
-  rewriteAndExpect(wrapBlock(code), wrapBlock(code), true, opts)
+  return rewriteAndExpect(wrapBlock(code), wrapBlock(code), true, opts)
 }
 
 const rewriteAndExpect = (code, expect, block, opts) => {
   code = !block ? `{${code}}` : code
   const rewritten = rewriteAst(code, opts)
   expectAst(rewritten, expect)
+  return rewritten
 }
 
 const rewriteAndExpectError = (code) => {

--- a/test/util.js
+++ b/test/util.js
@@ -21,6 +21,7 @@ const removeSourceMap = (code) => {
 
 const csiMethods = [
   { src: 'plusOperator', operator: true },
+  { src: 'tplOperator', operator: true },
   { src: 'substring', dst: 'stringSubstring' },
   { src: 'trim' },
   { src: 'trimStart' },


### PR DESCRIPTION
### What does this PR do?

- Takes the original template literal, extracts its arguments and creates a new expression calling the `tplOperator` taint tracking function, using a new template literal but with the new extracted variables.

```javascript
// original
const a = `Hello ${b}`

// rewritten
const a = (__datadog_test_0 = b, _ddiast.tplOperator(`Hello ${__datadog_test_0}`, __datadog_test_0))
```

- Template literal rewriting is configurable via new csi method property (the same way as the + operator):
`{ src: 'tplOperator', operator: true },`

### Motivation

<!-- What inspired you to submit this pull request? -->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
