### PR TITLE
Create a prefix in each instrumented file

### DIFF
--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -181,11 +181,11 @@ fn generate_prefix_stmts(config: &Config) -> Vec<Stmt> {
     let compiler = Compiler::new(Arc::new(swc_common::SourceMap::new(
         FilePathMapping::empty(),
     )));
+
     let handler_opts = HandlerOpts {
         color: ColorConfig::Never,
         skip_filename: false,
     };
-
     let program_result = try_with_handler(compiler.cm.clone(), handler_opts, |handler| {
         let source_file = compiler.cm.new_source_file(
             Arc::new(FileName::Real(PathBuf::from("inline.js".to_string()))),

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -32,8 +32,9 @@ use swc_common::{
     errors::{ColorConfig, Handler},
     FileName, FilePathMapping, SourceFile,
 };
-use swc_ecma_ast::{EsVersion, Program};
+use swc_ecma_ast::{EsVersion, Program, Stmt};
 
+use std::fmt;
 use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_visit::VisitMutWith;
 
@@ -58,7 +59,6 @@ pub struct TransformOutputWithStatus {
     pub literals_result: Option<LiteralsResult>,
 }
 
-#[derive(Debug)]
 pub struct Config {
     pub chain_source_map: bool,
     pub print_comments: bool,
@@ -66,6 +66,21 @@ pub struct Config {
     pub csi_methods: CsiMethods,
     pub verbosity: TelemetryVerbosity,
     pub literals: bool,
+    pub file_prefix_code: Vec<Stmt>,
+}
+
+impl fmt::Debug for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Config")
+            .field("chain_source_map", &self.chain_source_map)
+            .field("print_comments", &self.print_comments)
+            .field("local_var_prefix", &self.local_var_prefix)
+            .field("csi_methods", &self.csi_methods)
+            .field("verbosity", &self.verbosity)
+            .field("literals", &self.literals)
+            // file_prefix_code intentionally ignored
+            .finish()
+    }
 }
 
 pub fn rewrite_js<R: Read>(
@@ -144,7 +159,7 @@ fn default_handler_opts() -> HandlerOpts {
     }
 }
 
-fn parse_js(
+pub fn parse_js(
     source_file: &Arc<SourceFile>,
     handler: &Handler,
     compiler: &Compiler,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -61,6 +61,7 @@ fn rewrite_js_with_csi_methods(
             csi_methods: csi_methods.clone(),
             verbosity: TelemetryVerbosity::Information,
             literals: false,
+            file_prefix_code: Vec::new(),
         },
         &source_map_reader,
     )
@@ -101,6 +102,7 @@ fn get_default_config_with_verbosity(
         csi_methods: get_default_csi_methods(),
         verbosity,
         literals: false,
+        file_prefix_code: Vec::new(),
     }
 }
 
@@ -112,6 +114,7 @@ fn get_chained_and_print_comments_config() -> Config {
         csi_methods: get_default_csi_methods(),
         verbosity: TelemetryVerbosity::Debug,
         literals: false,
+        file_prefix_code: Vec::new(),
     }
 }
 
@@ -123,6 +126,7 @@ fn get_literals_config() -> Config {
         csi_methods: get_default_csi_methods(),
         verbosity: TelemetryVerbosity::Debug,
         literals: true,
+        file_prefix_code: Vec::new(),
     }
 }
 

--- a/src/visitor/block_transform_visitor.rs
+++ b/src/visitor/block_transform_visitor.rs
@@ -59,40 +59,6 @@ fn is_use_strict(stmt: &Stmt) -> bool {
 }
 
 impl VisitMut for BlockTransformVisitor<'_> {
-    fn visit_mut_program(&mut self, node: &mut Program) {
-        node.visit_mut_children_with(self);
-
-        if self.transform_status.status == Status::Modified {
-            match node {
-                Program::Script(script) => {
-                    let mut index = 0;
-                    if let Some(stmt) = script.body.first() {
-                        if is_use_strict(stmt) {
-                            index += 1;
-                        }
-                    }
-
-                    for prefix_statement in self.config.file_prefix_code.iter().rev() {
-                        script.body.insert(index, prefix_statement.clone());
-                    }
-                }
-                Program::Module(module) => {
-                    let mut index = 0;
-                    if let Some(ModuleItem::Stmt(stmt)) = module.body.first() {
-                        if is_use_strict(stmt) {
-                            index += 1;
-                        }
-                    }
-                    for prefix_statement in self.config.file_prefix_code.iter().rev() {
-                        module
-                            .body
-                            .insert(index, ModuleItem::Stmt(prefix_statement.clone()));
-                    }
-                }
-            }
-        }
-    }
-
     fn visit_mut_block_stmt(&mut self, expr: &mut BlockStmt) {
         if self.visit_is_cancelled() {
             return;
@@ -117,6 +83,41 @@ impl VisitMut for BlockTransformVisitor<'_> {
         }
 
         expr.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_program(&mut self, node: &mut Program) {
+        node.visit_mut_children_with(self);
+
+        if self.transform_status.status == Status::Modified {
+            match node {
+                Program::Script(script) => {
+                    let mut index = 0;
+                    if let Some(stmt) = script.body.first() {
+                        if is_use_strict(stmt) {
+                            index = 1;
+                        }
+                    }
+
+                    for prefix_statement in self.config.file_prefix_code.iter().rev() {
+                        script.body.insert(index, prefix_statement.clone());
+                    }
+                }
+                Program::Module(module) => {
+                    let mut index = 0;
+                    if let Some(ModuleItem::Stmt(stmt)) = module.body.first() {
+                        if is_use_strict(stmt) {
+                            index = 1;
+                        }
+                    }
+
+                    for prefix_statement in self.config.file_prefix_code.iter().rev() {
+                        module
+                            .body
+                            .insert(index, ModuleItem::Stmt(prefix_statement.clone()));
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/visitor/block_transform_visitor.rs
+++ b/src/visitor/block_transform_visitor.rs
@@ -1,8 +1,8 @@
-use super::{ident_provider::DefaultIdentProvider, visitor_with_context::Ctx};
 /**
 * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 **/
+use super::{ident_provider::DefaultIdentProvider, visitor_with_context::Ctx};
 use crate::{
     rewriter::Config,
     transform::transform_status::{Status, TransformStatus},

--- a/src/visitor/block_transform_visitor.rs
+++ b/src/visitor/block_transform_visitor.rs
@@ -1,3 +1,4 @@
+use super::{ident_provider::DefaultIdentProvider, visitor_with_context::Ctx};
 /**
 * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
 * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
@@ -14,7 +15,6 @@ use std::collections::HashSet;
 use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::{Stmt::Decl as DeclEnumOption, *};
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith};
-use super::{ident_provider::DefaultIdentProvider, visitor_with_context::Ctx};
 
 pub struct BlockTransformVisitor<'a> {
     pub transform_status: &'a mut TransformStatus,
@@ -51,10 +51,8 @@ impl Visit for BlockTransformVisitor<'_> {}
 
 fn is_use_strict(stmt: &Stmt) -> bool {
     if let Stmt::Expr(expr_stmt) = stmt {
-        if let Expr::Lit(lit) = &*expr_stmt.expr {
-            if let Lit::Str(Str { value, .. }) = lit {
-                return value == "use strict";
-            }
+        if let Expr::Lit(Lit::Str(Str { value, .. })) = &*expr_stmt.expr {
+            return value == "use strict";
         }
     }
     false
@@ -70,7 +68,7 @@ impl VisitMut for BlockTransformVisitor<'_> {
                 let mut index = 0;
                 if let Some(stmt) = script.body.first() {
                     if is_use_strict(stmt) {
-                        index = index + 1;
+                        index += 1;
                     }
                 }
 

--- a/src/visitor/block_transform_visitor.rs
+++ b/src/visitor/block_transform_visitor.rs
@@ -51,6 +51,20 @@ impl BlockTransformVisitor<'_> {
 impl Visit for BlockTransformVisitor<'_> {}
 
 impl VisitMut for BlockTransformVisitor<'_> {
+    fn visit_mut_program(&mut self, node: &mut Program) {
+        node.visit_mut_children_with(self);
+        // TODO prepend
+        //  if (typeof _ddiast === 'undefined') (function (globals) { const noop = (res) => res; globals._ddiast = { csimethod: noop,... } })((1,eval)('this'))
+
+        if self.transform_status.status == Status::Modified {
+            if let Program::Script(script) = node {
+                for prefix_statement in self.config.file_prefix_code.iter().rev() {
+                    script.body.insert(0, prefix_statement.clone());
+                }
+            }
+        }
+    }
+
     fn visit_mut_block_stmt(&mut self, expr: &mut BlockStmt) {
         if self.visit_is_cancelled() {
             return;

--- a/test/initialization-prefix.spec.js
+++ b/test/initialization-prefix.spec.js
@@ -1,0 +1,85 @@
+/**
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+ **/
+/* eslint-disable no-unused-expressions */
+
+const { rewriteAndExpectNoTransformation, rewriteAst, wrapBlock } = require('./util')
+
+const testOptions = {
+  keepPrefix: true,
+  csiMethods: [{
+    src: 'trim'
+  }]
+}
+
+const EXPECTED_PREFIX = `;
+if (typeof _ddiast === 'undefined') (function(globals) {
+    const noop = (res)=>res;
+    globals._ddiast = globals._ddiast || {
+        trim: noop
+    };
+}((1, eval)('this')));`
+
+describe('Initialization prefix', () => {
+  describe('Rewrites', () => {
+    it('should not add prefix when the file is not modified', () => {
+      const js = 'const a = 12'
+
+      rewriteAndExpectNoTransformation(js, testOptions)
+    })
+
+    it('should add prefix in rewritten files', () => {
+      const js = 'a.trim();'
+      const rewritten = rewriteAst(wrapBlock(js), testOptions)
+      expect(rewritten.startsWith(EXPECTED_PREFIX)).to.be.true
+    })
+
+    it('should maintain \'use strict\' at the begining', () => {
+      const js = `'use strict'
+function a() { a.trim() }`
+      const rewritten = rewriteAst(js, testOptions)
+      expect(rewritten).to.include(EXPECTED_PREFIX)
+      expect(rewritten.startsWith('\'use strict\'')).to.be.true
+    })
+
+    it('should maintain \'use strict\' at the beginning ignoring comments', () => {
+      const js = `// test
+'use strict'
+function a() { a.trim() }`
+      const rewritten = rewriteAst(js, testOptions)
+
+      expect(rewritten.startsWith(`'use strict';\n${EXPECTED_PREFIX}`)).to.be.true
+    })
+
+    it('should maintain "use strict" at the begining', () => {
+      const js = `"use strict"
+function a() { a.trim() }`
+      const rewritten = rewriteAst(js, testOptions)
+      expect(rewritten.startsWith(`"use strict";\n${EXPECTED_PREFIX}`)).to.be.true
+    })
+  })
+
+  describe('Execution', () => {
+    let _ddiast
+    beforeEach(() => {
+      _ddiast = global._ddiast
+      delete global._ddiast
+    })
+
+    afterEach(() => {
+      global._ddiast = _ddiast
+    })
+
+    it('should execute valid code when _ddiast is not defined yet', () => {
+      const code = `(val) => {
+  return val.trim()
+}`
+      const rewrittenCode = rewriteAst(code, testOptions)
+      // eslint-disable-next-line no-eval
+      const rewrittenFunction = (1, eval)(rewrittenCode)
+
+      expect(rewrittenFunction('   test   ')).to.be.equals('test')
+    })
+  })
+})

--- a/test/initialization-prefix.spec.js
+++ b/test/initialization-prefix.spec.js
@@ -33,20 +33,26 @@ describe('Initialization prefix', () => {
 
     it('should add prefix in rewritten files', () => {
       const js = 'a.trim();'
+
       const rewritten = rewriteAst(wrapBlock(js), testOptions)
+
       expect(rewritten.startsWith(EXPECTED_PREFIX)).to.be.true
     })
 
     it('should add prefix in rewritten files in ESM modules', () => {
       const js = 'import { a } from "a"; { a.trim() }'
+
       const rewritten = rewriteAst(js, testOptions)
+
       expect(rewritten.startsWith(EXPECTED_PREFIX)).to.be.true
     })
 
     it("should maintain 'use strict' at the beginning", () => {
       const js = `'use strict'
 function a() { a.trim() }`
+
       const rewritten = rewriteAst(js, testOptions)
+
       expect(rewritten).to.include(EXPECTED_PREFIX)
       expect(rewritten.startsWith("'use strict'")).to.be.true
     })
@@ -55,7 +61,9 @@ function a() { a.trim() }`
       const js = `'use strict'
 import { a } from "a";
 function a() { a.trim() }`
+
       const rewritten = rewriteAst(js, testOptions)
+
       expect(rewritten).to.include(EXPECTED_PREFIX)
       expect(rewritten.startsWith("'use strict'")).to.be.true
     })
@@ -64,6 +72,7 @@ function a() { a.trim() }`
       const js = `// test
 'use strict'
 function a() { a.trim() }`
+
       const rewritten = rewriteAst(js, testOptions)
 
       expect(rewritten.startsWith(`'use strict';\n${EXPECTED_PREFIX}`)).to.be.true
@@ -72,7 +81,9 @@ function a() { a.trim() }`
     it('should maintain "use strict" at the beginning', () => {
       const js = `"use strict"
 function a() { a.trim() }`
+
       const rewritten = rewriteAst(js, testOptions)
+
       expect(rewritten.startsWith(`"use strict";\n${EXPECTED_PREFIX}`)).to.be.true
     })
 
@@ -83,6 +94,7 @@ function a() { a.trim() }`
       const js = `${comment}
 "use strict"
 function a() { a.trim() }`
+
       const rewritten = rewriteAst(js, { ...testOptions, comments: true })
 
       expect(rewritten.startsWith(`${comment} "use strict";\n${EXPECTED_PREFIX}`)).to.be.true
@@ -93,6 +105,7 @@ function a() { a.trim() }`
       const js = `${comment}
 "use strict"
 function a() { a.trim() }`
+
       const rewritten = rewriteAst(js, { ...testOptions, comments: true })
 
       expect(rewritten.startsWith(`${comment}\n"use strict";\n${EXPECTED_PREFIX}`)).to.be.true
@@ -112,6 +125,7 @@ function a() { a.trim() }`
 
   describe('Execution', () => {
     let _ddiast
+
     beforeEach(() => {
       _ddiast = global._ddiast
       delete global._ddiast
@@ -126,6 +140,7 @@ function a() { a.trim() }`
   return val.trim()
 }`
       const rewrittenCode = rewriteAst(code, testOptions)
+
       // eslint-disable-next-line no-eval
       const rewrittenFunction = (1, eval)(rewrittenCode)
 
@@ -146,6 +161,7 @@ function a() { a.trim() }`
         ]
       }
       const rewrittenCode = rewriteAst(code, newTestOptions)
+
       // eslint-disable-next-line no-eval
       const rewrittenFunction = (1, eval)(rewrittenCode)
 

--- a/test/util.js
+++ b/test/util.js
@@ -19,6 +19,16 @@ const removeSourceMap = (code) => {
     .join('\n')
 }
 
+const removePrefix = (code) => {
+  const PREFIX_DETECTOR = "((1, eval)('this')));"
+  const prefixIndex = code.indexOf(PREFIX_DETECTOR)
+  if (prefixIndex > -1) {
+    return code.substring(prefixIndex + PREFIX_DETECTOR.length).trim()
+  }
+
+  return code
+}
+
 const csiMethods = [
   { src: 'plusOperator', operator: true },
   { src: 'tplOperator', operator: true },
@@ -43,7 +53,9 @@ const rewriteWithOpts = (code, opts) => {
     {
       localVarPrefix: 'test',
       csiMethods,
-      telemetryVerbosity: TELEMETRY_VERBOSITY
+      telemetryVerbosity: TELEMETRY_VERBOSITY,
+      logLevel: 'DEBUG',
+      logger: console
     },
     opts || {}
   )
@@ -55,7 +67,20 @@ const rewriteWithOpts = (code, opts) => {
 
 const rewriteAst = (code, opts) => {
   const rewritten = rewriteWithOpts(code, opts)
-  return opts && opts.keepSourceMap ? rewritten.content : removeSourceMap(rewritten.content)
+  let content = rewritten.content
+  if (opts) {
+    if (!opts.keepSourceMap) {
+      content = removeSourceMap(content)
+    }
+
+    if (!opts.keepPrefix) {
+      content = removePrefix(content)
+    }
+
+    return content
+  } else {
+    return removePrefix(removeSourceMap(content))
+  }
 }
 
 const wrapBlock = (code) => `{${os.EOL}${code}${os.EOL}}`
@@ -88,10 +113,12 @@ const getGlobalMethods = function (methods) {
 
 const expectAst = (received, expected) => {
   const rLines = received
+    .trim()
     .split('\n') // it seems that rewriter do not take into account OS line endings
     .map((l) => l.trim())
     .join('\n')
   const eLines = expected
+    .trim()
     .split('\n')
     .map((l) => l.trim())
     .join('\n')

--- a/test/util.js
+++ b/test/util.js
@@ -53,9 +53,7 @@ const rewriteWithOpts = (code, opts) => {
     {
       localVarPrefix: 'test',
       csiMethods,
-      telemetryVerbosity: TELEMETRY_VERBOSITY,
-      logLevel: 'DEBUG',
-      logger: console
+      telemetryVerbosity: TELEMETRY_VERBOSITY
     },
     opts || {}
   )


### PR DESCRIPTION
### What does this PR do?
Add a prefix in each instrumented file to prevent crashes when the `global._ddiast` object is not initialized.
<!-- A brief description of the change being made with this pull request. -->

### Motivation

<!-- What inspired you to submit this pull request? -->
When instrumentation is done with ESM, we can not be sure that the rewrite is coming from a thread where tracer and iast are initialized.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
