### PR TITLE
Create a NonCacheRewriter and export cacheRewrittenSourceMap

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,6 @@ export class NonCacheRewriter {
   csiMethods(): Array<string>
 }
 
-export class Rewriter extends NonCacheRewriter {}
+export const Rewriter: NonCacheRewriter
 
 export function cacheRewrittenSourceMap(filename: string, fileContent: string): void

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,8 +40,12 @@ export interface LiteralInfo {
   value: string
   locations: Array<LiteralLocation>
 }
-export class Rewriter {
+export class NonCacheRewriter {
   constructor(config?: RewriterConfig | undefined | null)
   rewrite(code: string, file: string): Result
   csiMethods(): Array<string>
 }
+
+export class Rewriter extends NonCacheRewriter {}
+
+export function cacheRewrittenSourceMap(filename: string, fileContent: string): void

--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -30,33 +30,69 @@ describe('main', () => {
         cacheRewrittenSourceMap
       }
     })
-
-    rewriter = new main.Rewriter()
   })
 
-  it('loads sourceMap when source file has been modified', () => {
-    status = 'modified'
+  describe('default Rewriter', () => {
+    beforeEach(() => {
+      rewriter = new main.Rewriter()
+    })
 
-    const response = rewriter.rewrite('content', 'file')
+    it('loads sourceMap when source file has been modified', () => {
+      status = 'modified'
 
-    expect(response.metrics.status).to.eq('modified')
-    expect(cacheRewrittenSourceMap).to.be.calledOnceWith('file', 'content')
+      const response = rewriter.rewrite('content', 'file')
+
+      expect(response.metrics.status).to.eq('modified')
+      expect(cacheRewrittenSourceMap).to.be.calledOnceWith('file', 'content')
+    })
+
+    it('does not load sourceMap when source file has not been modified', () => {
+      status = 'notmodified'
+
+      const response = rewriter.rewrite('content', 'file')
+
+      expect(response.metrics.status).to.eq('notmodified')
+      expect(cacheRewrittenSourceMap).to.not.be.called
+    })
+
+    it('should catch errors produced in cacheRewrittenSourceMap', () => {
+      status = 'modified'
+
+      cacheRewrittenSourceMap.throws(() => new Error('Error reading sourceMap file'))
+
+      expect(() => rewriter.rewrite('content', 'file')).to.not.throw()
+    })
   })
 
-  it('does not load sourceMap when source file has not been modified', () => {
-    status = 'notmodified'
+  describe('NonCacheRewriter', () => {
+    beforeEach(() => {
+      rewriter = new main.NonCacheRewriter()
+    })
 
-    const response = rewriter.rewrite('content', 'file')
+    it('does not load sourceMap when source file has been modified', () => {
+      status = 'modified'
 
-    expect(response.metrics.status).to.eq('notmodified')
-    expect(cacheRewrittenSourceMap).to.not.be.called
-  })
+      const response = rewriter.rewrite('content', 'file')
 
-  it('should catch errors produced in cacheRewrittenSourceMap', () => {
-    status = 'modified'
+      expect(response.metrics.status).to.eq('modified')
+      expect(cacheRewrittenSourceMap).to.not.be.called
+    })
 
-    cacheRewrittenSourceMap.throws(() => new Error('Error reading sourceMap file'))
+    it('does not load sourceMap when source file has not been modified', () => {
+      status = 'notmodified'
 
-    expect(() => rewriter.rewrite('content', 'file')).to.not.throw()
+      const response = rewriter.rewrite('content', 'file')
+
+      expect(response.metrics.status).to.eq('notmodified')
+      expect(cacheRewrittenSourceMap).to.not.be.called
+    })
+
+    it('should catch errors produced in cacheRewrittenSourceMap', () => {
+      status = 'modified'
+
+      cacheRewrittenSourceMap.throws(() => new Error('Error reading sourceMap file'))
+
+      expect(() => rewriter.rewrite('content', 'file')).to.not.throw()
+    })
   })
 })


### PR DESCRIPTION
### What does this PR do?
Create a NonCacheRewriter class and export cacheRewrittenSourceMap method.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
Use this in independent thread to rewrite esm files without loading the cache in this thread, and update the cache in the main thread using exported method.

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Describe how to test your changes

<!--
Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment
for testing, if the process requires more than just
running on one of the supported platforms.
-->

### Checklist

<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The CHANGELOG.md has been updated
- [ ] Unit tests have been updated and pass
- [ ] If known, an appropriate milestone has been selected
